### PR TITLE
Return early if route is not present.

### DIFF
--- a/routingtable/locRIB/loc_rib.go
+++ b/routingtable/locRIB/loc_rib.go
@@ -74,6 +74,8 @@ func (a *LocRIB) RemovePath(pfx net.Prefix, p *route.Path) bool {
 	r := a.rt.Get(pfx)
 	if r != nil {
 		oldRoute = r.Copy()
+	} else {
+		return true
 	}
 
 	a.rt.RemovePath(pfx, p)

--- a/routingtable/locRIB/loc_rib_test.go
+++ b/routingtable/locRIB/loc_rib_test.go
@@ -84,3 +84,14 @@ func TestContainsPfxPath(t *testing.T) {
 		assert.Equal(t, tc.expected, contains, "mismatch in testcase %v", i)
 	}
 }
+
+func TestLocRIB_RemovePathUnknown(t *testing.T) {
+	rib := New()
+	assert.True(t, rib.RemovePath(net.NewPfx(1, 32),
+		&route.Path{
+			Type: route.StaticPathType,
+			StaticPath: &route.StaticPath{
+				NextHop: 2,
+			},
+		}))
+}


### PR DESCRIPTION
We do not need to update any clients or select new best paths