### PR TITLE
Feature: allow users to use filters infront of loc rib

### DIFF
--- a/protocols/bgp/server/fsm.go
+++ b/protocols/bgp/server/fsm.go
@@ -16,7 +16,6 @@ import (
 	"github.com/bio-routing/bio-rd/routingtable/adjRIBIn"
 	"github.com/bio-routing/bio-rd/routingtable/adjRIBOut"
 	"github.com/bio-routing/bio-rd/routingtable/adjRIBOutAddPath"
-	"github.com/bio-routing/bio-rd/routingtable/locRIB"
 	log "github.com/sirupsen/logrus"
 	tomb "gopkg.in/tomb.v2"
 )
@@ -92,7 +91,7 @@ type FSM struct {
 
 	adjRIBIn     *adjRIBIn.AdjRIBIn
 	adjRIBOut    routingtable.RouteTableClient
-	rib          *locRIB.LocRIB
+	rib          routingtable.RouteTableClient
 	updateSender routingtable.RouteTableClient
 
 	capAddPathSend bool
@@ -109,7 +108,7 @@ type msgRecvErr struct {
 	con *net.TCPConn
 }
 
-func NewFSM(peer *Peer, c config.Peer, rib *locRIB.LocRIB) *FSM {
+func NewFSM(peer *Peer, c config.Peer, rib routingtable.RouteTableClient) *FSM {
 	fsm := &FSM{
 		peer:              peer,
 		state:             Idle,

--- a/protocols/bgp/server/peer.go
+++ b/protocols/bgp/server/peer.go
@@ -3,25 +3,23 @@ package server
 import (
 	"net"
 
+	"github.com/bio-routing/bio-rd/config"
 	"github.com/bio-routing/bio-rd/protocols/bgp/packet"
 	"github.com/bio-routing/bio-rd/routingtable"
-	"github.com/bio-routing/bio-rd/routingtable/locRIB"
-
-	"github.com/bio-routing/bio-rd/config"
 )
 
 type Peer struct {
 	addr          net.IP
 	asn           uint32
 	fsm           *FSM
-	rib           *locRIB.LocRIB
+	rib           routingtable.RouteTableClient
 	routerID      uint32
 	addPathSend   routingtable.ClientOptions
 	addPathRecv   bool
 	optOpenParams []packet.OptParam
 }
 
-func NewPeer(c config.Peer, rib *locRIB.LocRIB) (*Peer, error) {
+func NewPeer(c config.Peer, rib routingtable.RouteTableClient) (*Peer, error) {
 	p := &Peer{
 		addr:          c.PeerAddress,
 		asn:           c.PeerAS,

--- a/protocols/bgp/server/server.go
+++ b/protocols/bgp/server/server.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/bio-routing/bio-rd/config"
 	"github.com/bio-routing/bio-rd/protocols/bgp/packet"
-	"github.com/bio-routing/bio-rd/routingtable/locRIB"
+	"github.com/bio-routing/bio-rd/routingtable"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -84,7 +84,7 @@ func (b *BGPServer) incomingConnectionWorker() {
 	}
 }
 
-func (b *BGPServer) AddPeer(c config.Peer, rib *locRIB.LocRIB) error {
+func (b *BGPServer) AddPeer(c config.Peer, rib routingtable.RouteTableClient) error {
 	if c.LocalAS > uint16max || c.PeerAS > uint16max {
 		return fmt.Errorf("32bit ASNs are not supported yet")
 	}

--- a/routingtable/adjRIBIn/adj_rib_in_test.go
+++ b/routingtable/adjRIBIn/adj_rib_in_test.go
@@ -34,6 +34,10 @@ func (m *RTMockClient) Register(routingtable.RouteTableClient) {
 	return
 }
 
+func (m *RTMockClient) RegisterWithOptions(routingtable.RouteTableClient, routingtable.ClientOptions) {
+	return
+}
+
 func (m *RTMockClient) Unregister(routingtable.RouteTableClient) {
 	return
 }

--- a/routingtable/client_interface.go
+++ b/routingtable/client_interface.go
@@ -11,5 +11,6 @@ type RouteTableClient interface {
 	RemovePath(net.Prefix, *route.Path) bool
 	UpdateNewClient(RouteTableClient) error
 	Register(RouteTableClient)
+	RegisterWithOptions(RouteTableClient, ClientOptions)
 	Unregister(RouteTableClient)
 }

--- a/routingtable/client_manager_test.go
+++ b/routingtable/client_manager_test.go
@@ -25,6 +25,11 @@ func (m MockClient) UpdateNewClient(RouteTableClient) error {
 func (m MockClient) Register(RouteTableClient) {
 	return
 }
+
+func (m MockClient) RegisterWithOptions(RouteTableClient, ClientOptions) {
+	return
+}
+
 func (m MockClient) Unregister(RouteTableClient) {
 	return
 }

--- a/routingtable/filter/term_condition.go
+++ b/routingtable/filter/term_condition.go
@@ -10,6 +10,13 @@ type TermCondition struct {
 	routeFilters []*RouteFilter
 }
 
+func NewTermCondition(prefixLists []*PrefixList, routeFilters []*RouteFilter) *TermCondition {
+	return &TermCondition{
+		prefixLists:  prefixLists,
+		routeFilters: routeFilters,
+	}
+}
+
 func (f *TermCondition) Matches(p net.Prefix, pa *route.Path) bool {
 	return f.matchesAnyPrefixList(p) || f.machtchesAnyRouteFilter(p)
 }

--- a/routingtable/filter/term_condition_test.go
+++ b/routingtable/filter/term_condition_test.go
@@ -109,10 +109,10 @@ func TestMatches(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(te *testing.T) {
-			f := &TermCondition{
-				prefixLists:  test.prefixLists,
-				routeFilters: test.routeFilters,
-			}
+			f := NewTermCondition(
+				test.prefixLists,
+				test.routeFilters,
+			)
 
 			assert.Equal(te, test.expected, f.Matches(test.prefix, &route.Path{}))
 		})

--- a/routingtable/locRIB/loc_rib.go
+++ b/routingtable/locRIB/loc_rib.go
@@ -8,6 +8,7 @@ import (
 	"github.com/bio-routing/bio-rd/net"
 	"github.com/bio-routing/bio-rd/route"
 	"github.com/bio-routing/bio-rd/routingtable"
+	"github.com/sirupsen/logrus"
 )
 
 // LocRIB represents a routing information base
@@ -44,6 +45,10 @@ func (a *LocRIB) AddPath(pfx net.Prefix, p *route.Path) error {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
+	logrus.WithFields(map[string]interface{}{
+		"Prefix": pfx,
+		"Route":  p,
+	}).Debug("AddPath to locRIB")
 	routeExisted := false
 	oldRoute := &route.Route{}
 	r := a.rt.Get(pfx)
@@ -70,6 +75,10 @@ func (a *LocRIB) RemovePath(pfx net.Prefix, p *route.Path) bool {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
+	logrus.WithFields(map[string]interface{}{
+		"Prefix": pfx,
+		"Route":  p,
+	}).Debug("Remove from locRIB")
 	var oldRoute *route.Route
 	r := a.rt.Get(pfx)
 	if r != nil {


### PR DESCRIPTION
This patch allows a user to inject a Filter with LocRIB as backend into the FSM. I used it to create a locRIB which reject all announced prefixes from the adjRIBIN.