### PR TITLE
Fix: Deadlock in locRIB

### DIFF
--- a/routingtable/client_manager.go
+++ b/routingtable/client_manager.go
@@ -55,9 +55,8 @@ func (c *ClientManager) Register(client RouteTableClient) {
 // RegisterWithOptions registers a client with options for updates
 func (c *ClientManager) RegisterWithOptions(client RouteTableClient, opt ClientOptions) {
 	c.mu.Lock()
-	defer c.mu.Unlock()
-
 	c.clients[client] = opt
+	c.mu.Unlock()
 	c.master.UpdateNewClient(client)
 }
 


### PR DESCRIPTION
Release lock after updating map. UpdateNewClients may call GetOptions or Clients() and thus cause a deadlock.
