### PR TITLE
Moved RTMockClient into routingtable package to make it reusable.

### DIFF
--- a/routingtable/BUILD.bazel
+++ b/routingtable/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "client_interface.go",
         "client_manager.go",
         "contributing_asn_list.go",
+        "mock_client.go",
         "neighbor.go",
         "rib_interface.go",
         "table.go",

--- a/routingtable/mock_client.go
+++ b/routingtable/mock_client.go
@@ -1,0 +1,52 @@
+package routingtable
+
+import (
+	"fmt"
+
+	"github.com/bio-routing/bio-rd/net"
+	"github.com/bio-routing/bio-rd/route"
+)
+
+type RemovePathParams struct {
+	Pfx  net.Prefix
+	Path *route.Path
+}
+
+type RTMockClient struct {
+	removePathParams RemovePathParams
+}
+
+func NewRTMockClient() *RTMockClient {
+	return &RTMockClient{}
+}
+
+func (m *RTMockClient) GetRemovePathParams() RemovePathParams {
+	return m.removePathParams
+}
+
+func (m *RTMockClient) AddPath(pfx net.Prefix, p *route.Path) error {
+	return nil
+}
+
+func (m *RTMockClient) UpdateNewClient(client RouteTableClient) error {
+	return fmt.Errorf("Not implemented")
+}
+
+func (m *RTMockClient) Register(RouteTableClient) {
+	return
+}
+
+func (m *RTMockClient) RegisterWithOptions(RouteTableClient, ClientOptions) {
+	return
+}
+
+func (m *RTMockClient) Unregister(RouteTableClient) {
+	return
+}
+
+// RemovePath removes the path for prefix `pfx`
+func (m *RTMockClient) RemovePath(pfx net.Prefix, p *route.Path) bool {
+	m.removePathParams.Pfx = pfx
+	m.removePathParams.Path = p
+	return true
+}


### PR DESCRIPTION
Signed-off-by: Maximilian Wilhelm <max@sdn.clinic>