### PR TITLE
Fix for eBGP Next-Hop Parsing

### DIFF
--- a/protocols/bgp/server/fsm_established.go
+++ b/protocols/bgp/server/fsm_established.go
@@ -60,11 +60,7 @@ func (s *establishedState) init() error {
 	if err != nil {
 		return fmt.Errorf("Unable to get local address: %v", err)
 	}
-	hostIP := net.ParseIP(host)
-	if hostIP == nil {
-		return fmt.Errorf("Unable to parse address")
-	}
-	localAddr, err := bnet.IPFromBytes(hostIP)
+	localAddr, err := bnet.IPFromString(host)
 	if err != nil {
 		return fmt.Errorf("Unable to parse address: %v", err)
 	}


### PR DESCRIPTION
local address was always 16 bytes which lead to invalid updates for non ipv6 eBGP sessions