### PR TITLE
added flag to allow ipv4 being advertised as MP

### DIFF
--- a/config/peer.go
+++ b/config/peer.go
@@ -11,21 +11,22 @@ import (
 
 // Peer defines the configuration for a BGP session
 type Peer struct {
-	AdminEnabled            bool
-	ReconnectInterval       time.Duration
-	KeepAlive               time.Duration
-	HoldTime                time.Duration
-	LocalAddress            bnet.IP
-	PeerAddress             bnet.IP
-	LocalAS                 uint32
-	PeerAS                  uint32
-	Passive                 bool
-	RouterID                uint32
-	RouteServerClient       bool
-	RouteReflectorClient    bool
-	RouteReflectorClusterID uint32
-	IPv4                    *AddressFamilyConfig
-	IPv6                    *AddressFamilyConfig
+	AdminEnabled               bool
+	ReconnectInterval          time.Duration
+	KeepAlive                  time.Duration
+	HoldTime                   time.Duration
+	LocalAddress               bnet.IP
+	PeerAddress                bnet.IP
+	LocalAS                    uint32
+	PeerAS                     uint32
+	Passive                    bool
+	RouterID                   uint32
+	RouteServerClient          bool
+	RouteReflectorClient       bool
+	RouteReflectorClusterID    uint32
+	AdvertiseIPv4MultiProtocol bool
+	IPv4                       *AddressFamilyConfig
+	IPv6                       *AddressFamilyConfig
 }
 
 // AddressFamilyConfig represents all configuration parameters specific for an address family

--- a/protocols/bgp/server/fsm_open_sent.go
+++ b/protocols/bgp/server/fsm_open_sent.go
@@ -182,6 +182,10 @@ func (s *openSentState) processMultiProtocolCapability(cap packet.MultiProtocolC
 		return
 	}
 
+	if cap.AFI == packet.IPv4AFI && !s.fsm.peer.ipv4MultiProtocolAdvertised {
+		return
+	}
+
 	f := s.fsm.addressFamily(cap.AFI, cap.SAFI)
 	if f != nil {
 		f.multiProtocol = true

--- a/protocols/bgp/server/peer.go
+++ b/protocols/bgp/server/peer.go
@@ -29,14 +29,15 @@ type peer struct {
 	fsms   []*FSM
 	fsmsMu sync.Mutex
 
-	routerID             uint32
-	reconnectInterval    time.Duration
-	keepaliveTime        time.Duration
-	holdTime             time.Duration
-	optOpenParams        []packet.OptParam
-	routeServerClient    bool
-	routeReflectorClient bool
-	clusterID            uint32
+	routerID                    uint32
+	reconnectInterval           time.Duration
+	keepaliveTime               time.Duration
+	holdTime                    time.Duration
+	optOpenParams               []packet.OptParam
+	routeServerClient           bool
+	routeReflectorClient        bool
+	ipv4MultiProtocolAdvertised bool
+	clusterID                   uint32
 
 	ipv4 *peerAddressFamily
 	ipv6 *peerAddressFamily
@@ -161,6 +162,11 @@ func newPeer(c config.Peer, server *bgpServer) (*peer, error) {
 	caps = append(caps, addPathCapabilities(c)...)
 
 	caps = append(caps, asn4Capability(c))
+
+	if c.IPv4 != nil && c.AdvertiseIPv4MultiProtocol {
+		caps = append(caps, multiProtocolCapability(packet.IPv4AFI))
+		p.ipv4MultiProtocolAdvertised = true
+	}
 
 	if c.IPv6 != nil {
 		p.ipv6 = &peerAddressFamily{


### PR DESCRIPTION
* we did not ignore IPv4 MP CAP when we didn't advertised IPv4 as MP
* IPv4 can now be advertised as MP