### PR TITLE
Apply gofmt and add check for CI

### DIFF
--- a/.circleci/check-gofmt
+++ b/.circleci/check-gofmt
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+result="$(gofmt -e -s -l . 2>&1 | grep -v '^vendor/' )"
+if [ -n "$result" ]; then
+  echo "Go code is not formatted, run 'gofmt -e -s -w .'" >&2
+  echo "$result"
+  exit 1
+else
+  echo "Go code is formatted well"
+fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,3 +18,4 @@ jobs:
       - run: go test -v -cover -coverprofile=coverage.out ./...
       - run: goveralls -coverprofile=coverage.out -service=circle-ci -repotoken=$COVERALLS_TOKEN
       - run: .circleci/build-examples
+      - run: .circleci/check-gofmt

--- a/examples/bgp/main_ipv6.go
+++ b/examples/bgp/main_ipv6.go
@@ -20,7 +20,7 @@ func startServer(b server.BGPServer, rib *locRIB.LocRIB) {
 	err := b.Start(&config.Global{
 		Listen: true,
 		LocalAddressList: []net.IP{
-			net.IP{0x20, 0x01, 0x6, 0x78, 0x1, 0xe0, 0, 0, 0, 0, 0, 0, 0, 0, 0xca, 0xfe},
+			{0x20, 0x01, 0x6, 0x78, 0x1, 0xe0, 0, 0, 0, 0, 0, 0, 0, 0, 0xca, 0xfe},
 		},
 	})
 	if err != nil {

--- a/examples/netlink/main_ipv6.go
+++ b/examples/netlink/main_ipv6.go
@@ -21,7 +21,7 @@ func startServer(b server.BGPServer, rib *locRIB.LocRIB) {
 	err := b.Start(&config.Global{
 		Listen: true,
 		LocalAddressList: []net.IP{
-			net.IP{0x20, 0x01, 0x6, 0x78, 0x1, 0xe0, 0, 0, 0, 0, 0, 0, 0, 0, 0xca, 0xfe},
+			{0x20, 0x01, 0x6, 0x78, 0x1, 0xe0, 0, 0, 0, 0, 0, 0, 0, 0, 0xca, 0xfe},
 		},
 	})
 	if err != nil {

--- a/protocols/bgp/packet/encoder_test.go
+++ b/protocols/bgp/packet/encoder_test.go
@@ -108,7 +108,7 @@ func TestSerializeOptParams(t *testing.T) {
 		{
 			name: "AddPath",
 			optParams: []OptParam{
-				OptParam{
+				{
 					Type:   2,
 					Length: 6,
 					Value: Capabilities{
@@ -129,7 +129,7 @@ func TestSerializeOptParams(t *testing.T) {
 		{
 			name: "Multi Protocol Support (IPv6), 32 bit ASNs",
 			optParams: []OptParam{
-				OptParam{
+				{
 					Length: 12,
 					Type:   CapabilitiesParamType,
 					Value: Capabilities{

--- a/protocols/bgp/server/bmp_router_test.go
+++ b/protocols/bgp/server/bmp_router_test.go
@@ -303,7 +303,7 @@ func TestProcessPeerUpNotification(t *testing.T) {
 				rib4: locRIB.New(),
 				rib6: locRIB.New(),
 				neighbors: map[[16]byte]*neighbor{
-					[16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0, 255, 1}: {
+					{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0, 255, 1}: {
 						localAS:     200,
 						peerAS:      100,
 						peerAddress: [16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0, 255, 1},
@@ -482,7 +482,7 @@ func TestProcessTerminationMsg(t *testing.T) {
 				address: net.IP{10, 20, 30, 40},
 				logger:  log.New(),
 				neighbors: map[[16]byte]*neighbor{
-					[16]byte{1, 2, 3}: &neighbor{},
+					{1, 2, 3}: {},
 				},
 			},
 			msg: &bmppkt.TerminationMessage{
@@ -509,7 +509,7 @@ func TestProcessTerminationMsg(t *testing.T) {
 				address: net.IP{10, 20, 30, 40},
 				logger:  log.New(),
 				neighbors: map[[16]byte]*neighbor{
-					[16]byte{1, 2, 3}: &neighbor{},
+					{1, 2, 3}: {},
 				},
 			},
 			msg: &bmppkt.TerminationMessage{
@@ -575,7 +575,7 @@ func TestProcessPeerDownNotification(t *testing.T) {
 				address: net.IP{10, 20, 30, 40},
 				logger:  log.New(),
 				neighbors: map[[16]byte]*neighbor{
-					[16]byte{1, 2, 3}: &neighbor{},
+					{1, 2, 3}: {},
 				},
 			},
 			msg: &bmppkt.PeerDownNotification{
@@ -595,7 +595,7 @@ func TestProcessPeerDownNotification(t *testing.T) {
 				address: net.IP{10, 20, 30, 40},
 				logger:  log.New(),
 				neighbors: map[[16]byte]*neighbor{
-					[16]byte{1, 2, 3}: &neighbor{},
+					{1, 2, 3}: {},
 				},
 			},
 			msg: &bmppkt.PeerDownNotification{
@@ -607,7 +607,7 @@ func TestProcessPeerDownNotification(t *testing.T) {
 			expected: &router{
 				address: net.IP{10, 20, 30, 40},
 				neighbors: map[[16]byte]*neighbor{
-					[16]byte{1, 2, 3}: &neighbor{},
+					{1, 2, 3}: {},
 				},
 			},
 		},
@@ -650,10 +650,10 @@ func TestRegisterClients(t *testing.T) {
 		client: client6,
 	}
 	clients4 := map[afiClient]struct{}{
-		ac4: struct{}{},
+		ac4: {},
 	}
 	clients6 := map[afiClient]struct{}{
-		ac6: struct{}{},
+		ac6: {},
 	}
 
 	n.registerClients(clients4)

--- a/protocols/bgp/server/bmp_server_test.go
+++ b/protocols/bgp/server/bmp_server_test.go
@@ -27,28 +27,28 @@ func TestSubscribeRIBs(t *testing.T) {
 			srv: &BMPServer{
 				routers: make(map[string]*router),
 				ribClients: map[string]map[afiClient]struct{}{
-					"20.30.40.50": map[afiClient]struct{}{
-						afiClient{
+					"20.30.40.50": {
+						{
 							afi:    packet.IPv4AFI,
 							client: nil,
-						}: struct{}{},
+						}: {},
 					},
 				},
 			},
 			expected: &BMPServer{
 				routers: make(map[string]*router),
 				ribClients: map[string]map[afiClient]struct{}{
-					"20.30.40.50": map[afiClient]struct{}{
-						afiClient{
+					"20.30.40.50": {
+						{
 							afi:    packet.IPv4AFI,
 							client: nil,
-						}: struct{}{},
+						}: {},
 					},
-					"10.20.30.40": map[afiClient]struct{}{
-						afiClient{
+					"10.20.30.40": {
+						{
 							afi:    packet.IPv4AFI,
 							client: nil,
-						}: struct{}{},
+						}: {},
 					},
 				},
 			},
@@ -57,7 +57,7 @@ func TestSubscribeRIBs(t *testing.T) {
 			name: "Test with routers no clients",
 			srv: &BMPServer{
 				routers: map[string]*router{
-					"10.20.30.40": &router{
+					"10.20.30.40": {
 						ribClients: make(map[afiClient]struct{}),
 					},
 				},
@@ -65,21 +65,21 @@ func TestSubscribeRIBs(t *testing.T) {
 			},
 			expected: &BMPServer{
 				routers: map[string]*router{
-					"10.20.30.40": &router{
+					"10.20.30.40": {
 						ribClients: map[afiClient]struct{}{
-							afiClient{
+							{
 								afi:    packet.IPv4AFI,
 								client: nil,
-							}: struct{}{},
+							}: {},
 						},
 					},
 				},
 				ribClients: map[string]map[afiClient]struct{}{
-					"10.20.30.40": map[afiClient]struct{}{
-						afiClient{
+					"10.20.30.40": {
+						{
 							afi:    packet.IPv4AFI,
 							client: nil,
-						}: struct{}{},
+						}: {},
 					},
 				},
 			},
@@ -104,61 +104,60 @@ func TestUnsubscribeRIBs(t *testing.T) {
 			name: "Unsubscribe existing from router",
 			srv: &BMPServer{
 				routers: map[string]*router{
-					"10.20.30.40": &router{
+					"10.20.30.40": {
 						ribClients: map[afiClient]struct{}{
-							afiClient{
+							{
 								afi:    packet.IPv4AFI,
 								client: nil,
-							}: struct{}{},
+							}: {},
 						},
 					},
-					"20.30.40.50": &router{
+					"20.30.40.50": {
 						ribClients: map[afiClient]struct{}{
-							afiClient{
+							{
 								afi:    packet.IPv4AFI,
 								client: nil,
-							}: struct{}{},
+							}: {},
 						},
 					},
 				},
 				ribClients: map[string]map[afiClient]struct{}{
-					"20.30.40.50": map[afiClient]struct{}{
-						afiClient{
+					"20.30.40.50": {
+						{
 							afi:    packet.IPv4AFI,
 							client: nil,
-						}: struct{}{},
+						}: {},
 					},
-					"10.20.30.40": map[afiClient]struct{}{
-						afiClient{
+					"10.20.30.40": {
+						{
 							afi:    packet.IPv4AFI,
 							client: nil,
-						}: struct{}{},
+						}: {},
 					},
 				},
 			},
 			expected: &BMPServer{
 				routers: map[string]*router{
-					"10.20.30.40": &router{
+					"10.20.30.40": {
 						ribClients: map[afiClient]struct{}{},
 					},
-					"20.30.40.50": &router{
+					"20.30.40.50": {
 						ribClients: map[afiClient]struct{}{
-							afiClient{
+							{
 								afi:    packet.IPv4AFI,
 								client: nil,
-							}: struct{}{},
+							}: {},
 						},
 					},
 				},
 				ribClients: map[string]map[afiClient]struct{}{
-					"20.30.40.50": map[afiClient]struct{}{
-						afiClient{
+					"20.30.40.50": {
+						{
 							afi:    packet.IPv4AFI,
 							client: nil,
-						}: struct{}{},
+						}: {},
 					},
-					"10.20.30.40": map[afiClient]struct{}{
-					},
+					"10.20.30.40": {},
 				},
 			},
 		},
@@ -166,69 +165,69 @@ func TestUnsubscribeRIBs(t *testing.T) {
 			name: "Unsubscribe existing from non-router",
 			srv: &BMPServer{
 				routers: map[string]*router{
-					"10.20.30.60": &router{
+					"10.20.30.60": {
 						ribClients: map[afiClient]struct{}{
-							afiClient{
+							{
 								afi:    packet.IPv4AFI,
 								client: nil,
-							}: struct{}{},
+							}: {},
 						},
 					},
-					"20.30.40.50": &router{
+					"20.30.40.50": {
 						ribClients: map[afiClient]struct{}{
-							afiClient{
+							{
 								afi:    packet.IPv4AFI,
 								client: nil,
-							}: struct{}{},
+							}: {},
 						},
 					},
 				},
 				ribClients: map[string]map[afiClient]struct{}{
-					"20.30.40.50": map[afiClient]struct{}{
-						afiClient{
+					"20.30.40.50": {
+						{
 							afi:    packet.IPv4AFI,
 							client: nil,
-						}: struct{}{},
+						}: {},
 					},
-					"10.20.30.60": map[afiClient]struct{}{
-						afiClient{
+					"10.20.30.60": {
+						{
 							afi:    packet.IPv4AFI,
 							client: nil,
-						}: struct{}{},
+						}: {},
 					},
 				},
 			},
 			expected: &BMPServer{
 				routers: map[string]*router{
-					"10.20.30.60": &router{
+					"10.20.30.60": {
 						ribClients: map[afiClient]struct{}{
-							afiClient{
+							{
 								afi:    packet.IPv4AFI,
 								client: nil,
-							}: struct{}{},
+							}: {},
 						},
 					},
-					"20.30.40.50": &router{
+					"20.30.40.50": {
 						ribClients: map[afiClient]struct{}{
-							afiClient{
+							{
 								afi:    packet.IPv4AFI,
 								client: nil,
-							}: struct{}{},
+							}: {},
 						},
 					},
 				},
 				ribClients: map[string]map[afiClient]struct{}{
-					"20.30.40.50": map[afiClient]struct{}{
-						afiClient{
+					"20.30.40.50": {
+						{
 							afi:    packet.IPv4AFI,
 							client: nil,
-						}: struct{}{},
+						}: {},
 					},
-					"10.20.30.60": map[afiClient]struct{}{
-						afiClient{
+					"10.20.30.60": {
+						{
 							afi:    packet.IPv4AFI,
 							client: nil,
-						}: struct{}{},
+						}: {},
 					},
 				},
 			},
@@ -237,49 +236,49 @@ func TestUnsubscribeRIBs(t *testing.T) {
 			name: "Unsubscribe existing from non-existing client",
 			srv: &BMPServer{
 				routers: map[string]*router{
-					"10.20.30.40": &router{
+					"10.20.30.40": {
 						ribClients: map[afiClient]struct{}{},
 					},
-					"20.30.40.50": &router{
+					"20.30.40.50": {
 						ribClients: map[afiClient]struct{}{
-							afiClient{
+							{
 								afi:    packet.IPv4AFI,
 								client: nil,
-							}: struct{}{},
+							}: {},
 						},
 					},
 				},
 				ribClients: map[string]map[afiClient]struct{}{
-					"20.30.40.40": map[afiClient]struct{}{},
-					"10.20.30.60": map[afiClient]struct{}{
-						afiClient{
+					"20.30.40.40": {},
+					"10.20.30.60": {
+						{
 							afi:    packet.IPv4AFI,
 							client: nil,
-						}: struct{}{},
+						}: {},
 					},
 				},
 			},
 			expected: &BMPServer{
 				routers: map[string]*router{
-					"10.20.30.40": &router{
+					"10.20.30.40": {
 						ribClients: map[afiClient]struct{}{},
 					},
-					"20.30.40.50": &router{
+					"20.30.40.50": {
 						ribClients: map[afiClient]struct{}{
-							afiClient{
+							{
 								afi:    packet.IPv4AFI,
 								client: nil,
-							}: struct{}{},
+							}: {},
 						},
 					},
 				},
 				ribClients: map[string]map[afiClient]struct{}{
-					"20.30.40.40": map[afiClient]struct{}{},
-					"10.20.30.60": map[afiClient]struct{}{
-						afiClient{
+					"20.30.40.40": {},
+					"10.20.30.60": {
+						{
 							afi:    packet.IPv4AFI,
 							client: nil,
-						}: struct{}{},
+						}: {},
 					},
 				},
 			},

--- a/protocols/bgp/server/fsm_address_family_test.go
+++ b/protocols/bgp/server/fsm_address_family_test.go
@@ -51,7 +51,7 @@ func TestProcessAttributes(t *testing.T) {
 	f.processAttributes(asPath, p)
 
 	expectedCodes := []uint8{200, 100}
-	expectedValues := [][]byte{[]byte{5, 6}, []byte{1, 2, 3, 4}}
+	expectedValues := [][]byte{{5, 6}, {1, 2, 3, 4}}
 
 	i := 0
 	for _, attr := range p.BGPPath.UnknownAttributes {

--- a/protocols/bgp/server/fsm_open_sent_test.go
+++ b/protocols/bgp/server/fsm_open_sent_test.go
@@ -115,7 +115,7 @@ func TestProcessMultiProtocolCapability(t *testing.T) {
 				ipv4: &peerAddressFamily{},
 			},
 			caps: []packet.MultiProtocolCapability{
-				packet.MultiProtocolCapability{
+				{
 					AFI:  packet.IPv4AFI,
 					SAFI: packet.UnicastSAFI,
 				},
@@ -124,11 +124,11 @@ func TestProcessMultiProtocolCapability(t *testing.T) {
 		{
 			name: "IPv4 only with multi protocol configuration",
 			peer: &peer{
-				ipv4: &peerAddressFamily{},
+				ipv4:                        &peerAddressFamily{},
 				ipv4MultiProtocolAdvertised: true,
 			},
 			caps: []packet.MultiProtocolCapability{
-				packet.MultiProtocolCapability{
+				{
 					AFI:  packet.IPv4AFI,
 					SAFI: packet.UnicastSAFI,
 				},
@@ -141,7 +141,7 @@ func TestProcessMultiProtocolCapability(t *testing.T) {
 				ipv6: &peerAddressFamily{},
 			},
 			caps: []packet.MultiProtocolCapability{
-				packet.MultiProtocolCapability{
+				{
 					AFI:  packet.IPv6AFI,
 					SAFI: packet.UnicastSAFI,
 				},
@@ -155,11 +155,11 @@ func TestProcessMultiProtocolCapability(t *testing.T) {
 				ipv6: &peerAddressFamily{},
 			},
 			caps: []packet.MultiProtocolCapability{
-				packet.MultiProtocolCapability{
+				{
 					AFI:  packet.IPv6AFI,
 					SAFI: packet.UnicastSAFI,
 				},
-				packet.MultiProtocolCapability{
+				{
 					AFI:  packet.IPv4AFI,
 					SAFI: packet.UnicastSAFI,
 				},
@@ -169,16 +169,16 @@ func TestProcessMultiProtocolCapability(t *testing.T) {
 		{
 			name: "IPv4 and IPv6 configured as multi protocol",
 			peer: &peer{
-				ipv4: &peerAddressFamily{},
-				ipv6: &peerAddressFamily{},
+				ipv4:                        &peerAddressFamily{},
+				ipv6:                        &peerAddressFamily{},
 				ipv4MultiProtocolAdvertised: true,
 			},
 			caps: []packet.MultiProtocolCapability{
-				packet.MultiProtocolCapability{
+				{
 					AFI:  packet.IPv6AFI,
 					SAFI: packet.UnicastSAFI,
 				},
-				packet.MultiProtocolCapability{
+				{
 					AFI:  packet.IPv4AFI,
 					SAFI: packet.UnicastSAFI,
 				},

--- a/protocols/bgp/server/fsm_test.go
+++ b/protocols/bgp/server/fsm_test.go
@@ -260,7 +260,7 @@ func TestOpenMessage(t *testing.T) {
 				BGPIdentifier: 1,
 				HoldTime:      30,
 				OptParams: []packet.OptParam{
-					packet.OptParam{
+					{
 						Type: packet.CapabilitiesParamType,
 						Value: packet.Capabilities{
 							packet.Capability{
@@ -285,7 +285,7 @@ func TestOpenMessage(t *testing.T) {
 				BGPIdentifier: 1,
 				HoldTime:      30,
 				OptParams: []packet.OptParam{
-					packet.OptParam{
+					{
 						Type: packet.CapabilitiesParamType,
 						Value: packet.Capabilities{
 							packet.Capability{
@@ -309,7 +309,7 @@ func TestOpenMessage(t *testing.T) {
 				holdTime: test.holdTime,
 				routerID: test.routerID,
 				optOpenParams: []packet.OptParam{
-					packet.OptParam{
+					{
 						Type: packet.CapabilitiesParamType,
 						Value: packet.Capabilities{
 							packet.Capability{

--- a/route/bgp_test.go
+++ b/route/bgp_test.go
@@ -23,7 +23,7 @@ func TestComputeHash(t *testing.T) {
 		},
 		EBGP: false,
 		LargeCommunities: []types.LargeCommunity{
-			types.LargeCommunity{
+			{
 				DataPart1:           1,
 				DataPart2:           2,
 				GlobalAdministrator: 3,

--- a/route/route_test.go
+++ b/route/route_test.go
@@ -170,7 +170,7 @@ func TestNewRoute(t *testing.T) {
 			expected: &Route{
 				pfx: bnet.NewPfx(bnet.IPv4FromOctets(10, 0, 0, 0), 8),
 				paths: []*Path{
-					&Path{
+					{
 						Type:    BGPPathType,
 						BGPPath: &BGPPath{},
 					},

--- a/routingtable/adjRIBIn/adj_rib_in_test.go
+++ b/routingtable/adjRIBIn/adj_rib_in_test.go
@@ -327,17 +327,17 @@ func TestUnregister(t *testing.T) {
 	}
 
 	paths := []*route.Path{
-		&route.Path{
+		{
 			BGPPath: &route.BGPPath{
 				NextHop: net.IPv4FromOctets(192, 168, 0, 0),
 			},
 		},
-		&route.Path{
+		{
 			BGPPath: &route.BGPPath{
 				NextHop: net.IPv4FromOctets(192, 168, 2, 1),
 			},
 		},
-		&route.Path{
+		{
 			BGPPath: &route.BGPPath{
 				NextHop: net.IPv4FromOctets(192, 168, 3, 1),
 			},

--- a/routingtable/adjRIBOut/adj_rib_out_test.go
+++ b/routingtable/adjRIBOut/adj_rib_out_test.go
@@ -1126,7 +1126,7 @@ func TestAddPathIBGP(t *testing.T) {
 			},
 			expected: []*route.Route{
 				route.NewRouteAddPath(net.NewPfx(net.IPv4FromOctets(10, 0, 0, 0), 8), []*route.Path{
-					&route.Path{
+					{
 						Type: route.BGPPathType,
 						BGPPath: &route.BGPPath{
 							NextHop: net.IPv4FromOctets(1, 2, 3, 4),
@@ -1149,7 +1149,7 @@ func TestAddPathIBGP(t *testing.T) {
 							LocalPref:         0,
 							Source:            net.IP{}},
 					},
-					&route.Path{
+					{
 						Type: route.BGPPathType,
 						BGPPath: &route.BGPPath{
 							NextHop: net.IPv4FromOctets(2, 3, 4, 5),
@@ -1251,7 +1251,7 @@ func TestAddPathIBGP(t *testing.T) {
 			},
 			expected: []*route.Route{
 				route.NewRouteAddPath(net.NewPfx(net.IPv4FromOctets(10, 0, 0, 0), 8), []*route.Path{
-					&route.Path{
+					{
 						Type: route.BGPPathType,
 						BGPPath: &route.BGPPath{
 							NextHop: net.IPv4FromOctets(1, 2, 3, 4),
@@ -1274,7 +1274,7 @@ func TestAddPathIBGP(t *testing.T) {
 							LocalPref:         0,
 							Source:            net.IP{}},
 					},
-					&route.Path{
+					{
 						Type: route.BGPPathType,
 						BGPPath: &route.BGPPath{
 							NextHop: net.IPv4FromOctets(3, 4, 5, 6),
@@ -1325,7 +1325,7 @@ func TestAddPathIBGP(t *testing.T) {
 			},
 			expected: []*route.Route{
 				route.NewRouteAddPath(net.NewPfx(net.IPv4FromOctets(10, 0, 0, 0), 8), []*route.Path{
-					&route.Path{
+					{
 						Type: route.BGPPathType,
 						BGPPath: &route.BGPPath{
 							NextHop: net.IPv4FromOctets(1, 2, 3, 4),
@@ -1348,7 +1348,7 @@ func TestAddPathIBGP(t *testing.T) {
 							LocalPref:         0,
 							Source:            net.IP{}},
 					},
-					&route.Path{
+					{
 						Type: route.BGPPathType,
 						BGPPath: &route.BGPPath{
 							NextHop: net.IPv4FromOctets(3, 4, 5, 6),
@@ -1371,7 +1371,7 @@ func TestAddPathIBGP(t *testing.T) {
 							LocalPref:         0,
 							Source:            net.IP{}},
 					},
-					&route.Path{
+					{
 						Type: route.BGPPathType,
 						BGPPath: &route.BGPPath{
 							NextHop: net.IPv4FromOctets(4, 5, 6, 7),

--- a/routingtable/client_manager_test.go
+++ b/routingtable/client_manager_test.go
@@ -47,10 +47,10 @@ func TestClients(t *testing.T) {
 		{
 			name: "No clients",
 			clients: []MockClient{
-				MockClient{
+				{
 					foo: 1,
 				},
-				MockClient{
+				{
 					foo: 2,
 				},
 			},

--- a/routingtable/contributing_asn_list.go
+++ b/routingtable/contributing_asn_list.go
@@ -65,7 +65,7 @@ func (c *ContributingASNs) Remove(asn uint32) {
 
 		if cASN.count == 0 {
 			copy(asnList[i:], asnList[i+1:])
-			asnList = asnList[:len(asnList)]
+			asnList = asnList[:]
 			c.contributingASNs = asnList[:len(asnList)-1]
 		}
 

--- a/routingtable/filter/actions/add_large_community_action_test.go
+++ b/routingtable/filter/actions/add_large_community_action_test.go
@@ -19,7 +19,7 @@ func TestAddingLargeCommunities(t *testing.T) {
 		{
 			name: "add one to empty",
 			communities: []types.LargeCommunity{
-				types.LargeCommunity{
+				{
 					GlobalAdministrator: 1,
 					DataPart1:           2,
 					DataPart2:           3,
@@ -30,14 +30,14 @@ func TestAddingLargeCommunities(t *testing.T) {
 		{
 			name: "add one to existing",
 			current: []types.LargeCommunity{
-				types.LargeCommunity{
+				{
 					GlobalAdministrator: 5,
 					DataPart1:           6,
 					DataPart2:           7,
 				},
 			},
 			communities: []types.LargeCommunity{
-				types.LargeCommunity{
+				{
 					GlobalAdministrator: 1,
 					DataPart1:           2,
 					DataPart2:           3,
@@ -48,19 +48,19 @@ func TestAddingLargeCommunities(t *testing.T) {
 		{
 			name: "add two to existing",
 			current: []types.LargeCommunity{
-				types.LargeCommunity{
+				{
 					GlobalAdministrator: 5,
 					DataPart1:           6,
 					DataPart2:           7,
 				},
 			},
 			communities: []types.LargeCommunity{
-				types.LargeCommunity{
+				{
 					GlobalAdministrator: 1,
 					DataPart1:           2,
 					DataPart2:           3,
 				},
-				types.LargeCommunity{
+				{
 					GlobalAdministrator: 7,
 					DataPart1:           8,
 					DataPart2:           9,

--- a/routingtable/filter/term_condition_test.go
+++ b/routingtable/filter/term_condition_test.go
@@ -110,7 +110,7 @@ func TestMatches(t *testing.T) {
 				Communities: []uint32{65538, 196612, 327686}, // (1,2) (3,4) (5,6)
 			},
 			communityFilters: []*CommunityFilter{
-				&CommunityFilter{196612}, // (3,4)
+				{196612}, // (3,4)
 			},
 			expected: true,
 		},
@@ -121,7 +121,7 @@ func TestMatches(t *testing.T) {
 				Communities: []uint32{65538, 196612, 327686}, // (1,2) (3,4) (5,6)
 			},
 			communityFilters: []*CommunityFilter{
-				&CommunityFilter{196608}, // (3,0)
+				{196608}, // (3,0)
 			},
 			expected: false,
 		},
@@ -129,7 +129,7 @@ func TestMatches(t *testing.T) {
 			name:   "community filter, bgp path is nil",
 			prefix: net.NewPfx(net.IPv4FromOctets(10, 0, 0, 0), 24),
 			communityFilters: []*CommunityFilter{
-				&CommunityFilter{196608}, // (3,0)
+				{196608}, // (3,0)
 			},
 			expected: false,
 		},
@@ -138,12 +138,12 @@ func TestMatches(t *testing.T) {
 			prefix: net.NewPfx(net.IPv4FromOctets(10, 0, 0, 0), 24),
 			bgpPath: &route.BGPPath{
 				LargeCommunities: []types.LargeCommunity{
-					types.LargeCommunity{
+					{
 						GlobalAdministrator: 1,
 						DataPart1:           2,
 						DataPart2:           3,
 					},
-					types.LargeCommunity{
+					{
 						GlobalAdministrator: 1,
 						DataPart1:           2,
 						DataPart2:           0,


### PR DESCRIPTION
Go Report Card also runs `gofmt -s` to enable simplifications.