### PR TITLE
Remove goveralls

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,8 +14,8 @@ jobs:
       - run: curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
       - run: dep ensure -v
 
-      - run: go get github.com/mattn/goveralls
       - run: go test -v -cover -coverprofile=coverage.txt ./...
       - run: bash <(curl -s https://codecov.io/bash)
+
       - run: .circleci/build-examples
       - run: .circleci/check-gofmt


### PR DESCRIPTION
It was a dependency of Coveralls, so not required any more.