### PR TITLE
add vrf-id to existing vrf implementation

### DIFF
--- a/benchmarks/bgp/learning/main.go
+++ b/benchmarks/bgp/learning/main.go
@@ -31,7 +31,7 @@ func main() {
 	go http.ListenAndServe("localhost:1337", nil)
 
 	b := server.NewBgpServer()
-	v, err := vrf.New("master")
+	v, err := vrf.NewDefaultVRF()
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/bgp/main.go
+++ b/examples/bgp/main.go
@@ -18,7 +18,7 @@ func main() {
 	logrus.Printf("This is a BGP speaker\n")
 
 	b := server.NewBgpServer()
-	v, err := vrf.New("master")
+	v, err := vrf.NewDefaultVRF()
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/routingtable/vrf/vrf.go
+++ b/routingtable/vrf/vrf.go
@@ -35,8 +35,8 @@ func NewDefaultVRF() (*VRF, error) {
 // New creates a new VRF. The VRF is registered automatically to the global VRF registry.
 func New(name string, id uint32) (*VRF, error) {
 	v := newUntrackedVRF(name, id)
-	v.CreateIPv4UnicastLocRIB("inet.0")
-	v.CreateIPv6UnicastLocRIB("inet6.0")
+	v.CreateIPv4UnicastLocRIB(fmt.Sprintf("inet.%d", id))
+	v.CreateIPv6UnicastLocRIB(fmt.Sprintf("inet6.%d", id))
 
 	err := globalRegistry.registerVRF(v)
 	if err != nil {

--- a/routingtable/vrf/vrf.go
+++ b/routingtable/vrf/vrf.go
@@ -121,3 +121,16 @@ func (v *VRF) RIBByName(name string) (rib *locRIB.LocRIB, found bool) {
 	rib, found = v.ribNames[name]
 	return rib, found
 }
+
+// GetRIBNames returns an []string containing all rib-names
+func (v *VRF) GetRIBNames() []string {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	ribNames := make([]string, 0)
+	for ribName := range v.ribNames {
+		ribNames = append(ribNames, ribName)
+	}
+
+	return ribNames
+}

--- a/routingtable/vrf/vrf.go
+++ b/routingtable/vrf/vrf.go
@@ -26,7 +26,7 @@ type VRF struct {
 	ribNames map[string]*locRIB.LocRIB
 }
 
-// New creates a new VRF
+// New creates a new VRF. The VRF is registered automatically to the global VRF registry.
 func New(name string) (*VRF, error) {
 	v := newUntrackedVRF(name)
 	v.CreateIPv4UnicastLocRIB("inet.0")
@@ -87,6 +87,11 @@ func (v *VRF) IPv6UnicastRIB() *locRIB.LocRIB {
 
 func (v *VRF) Name() string {
 	return v.name
+}
+
+// Unregister removes this VRF from the global registry.
+func (v *VRF) Unregister() {
+	globalRegistry.unregisterVRF(v)
 }
 
 func (v *VRF) ribForAddressFamily(family addressFamily) *locRIB.LocRIB {

--- a/routingtable/vrf/vrf_registry.go
+++ b/routingtable/vrf/vrf_registry.go
@@ -13,11 +13,14 @@ func init() {
 	}
 }
 
+// vrfRegistry holds a reference to all active VRFs. Every VRF have to have a different name.
 type vrfRegistry struct {
 	vrfs map[string]*VRF
 	mu   sync.Mutex
 }
 
+// registerVRF adds the given VRF from the global registry.
+// An error is returned if there is already a VRF registered with the same name.
 func (r *vrfRegistry) registerVRF(v *VRF) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -29,4 +32,12 @@ func (r *vrfRegistry) registerVRF(v *VRF) error {
 
 	r.vrfs[v.name] = v
 	return nil
+}
+
+// unregisterVRF removes the given VRF from the global registry.
+func (r *vrfRegistry) unregisterVRF(v *VRF) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	delete(r.vrfs, v.name)
 }

--- a/routingtable/vrf/vrf_test.go
+++ b/routingtable/vrf/vrf_test.go
@@ -81,3 +81,15 @@ func TestUnregister(t *testing.T) {
 	_, found = globalRegistry.vrfsID[vrfID]
 	assert.False(t, found, "vrf must not be in global registry")
 }
+
+func TestGetRIBNames(t *testing.T) {
+	vrfName := "namedRIBs"
+	vrfID := uint32(8)
+	v, err := New(vrfName, vrfID)
+	assert.Nil(t, err, "error must be nil on first invokation")
+
+	ribNames := v.GetRIBNames()
+	expectedRibNames := []string{"inet.8", "inet6.8"}
+
+	assert.EqualValues(t, expectedRibNames, ribNames, "rib names must match")
+}

--- a/routingtable/vrf/vrf_test.go
+++ b/routingtable/vrf/vrf_test.go
@@ -53,3 +53,21 @@ func TestName(t *testing.T) {
 	v := newUntrackedVRF("foo")
 	assert.Equal(t, "foo", v.Name())
 }
+
+func TestUnregister(t *testing.T) {
+	vrfName := "registeredVRF"
+	v, err := New(vrfName)
+	assert.Nil(t, err, "error must be nil on first invokation")
+
+	_, err = New(vrfName)
+	assert.NotNil(t, err, "error must not be nil on second invokation")
+
+	_, found := globalRegistry.vrfs[vrfName]
+	assert.True(t, found, "vrf must be in global registry")
+
+	v.Unregister()
+
+	_, found = globalRegistry.vrfs[vrfName]
+	assert.False(t, found, "vrf must not be in global registry")
+
+}


### PR DESCRIPTION
Having IDs to vrf's is crucial for the FIB implementation that follows later, since the VRF-ID decides the routing table in the linux kernel implementation.


Cumulus networks add a feature for "auto assigning" the VRF-id, which i generally like:

```
cumulus@switch:~$ net add vrf rocket vrf-table auto
cumulus@switch:~$ net add interface swp1 vrf rocket
cumulus@switch:~$ net pending
cumulus@switch:~$ net commit
```
https://docs.cumulusnetworks.com/display/DOCS/Virtual+Routing+and+Forwarding+-+VRF


According to the docs the VRF-id is then selected from the range 1001 to 1255
I plan to do another PR where i add this feature as well, to automatically assign the VRF-id based on the information "what is available"