### PR TITLE
Move fsm state number constants to metrics package.

### DIFF
--- a/protocols/bgp/metrics/bgp_peer_metrics.go
+++ b/protocols/bgp/metrics/bgp_peer_metrics.go
@@ -6,6 +6,16 @@ import (
 	bnet "github.com/bio-routing/bio-rd/net"
 )
 
+const (
+	StateDown        = 0
+	StateIdle        = 1
+	StateConnect     = 2
+	StateActive      = 3
+	StateOpenSent    = 4
+	StateOpenConfirm = 5
+	StateEstablished = 6
+)
+
 // BGPPeerMetrics provides metrics for one BGP session
 type BGPPeerMetrics struct {
 	// IP is the remote IP of the peer

--- a/protocols/bgp/server/metrics_service.go
+++ b/protocols/bgp/server/metrics_service.go
@@ -4,16 +4,6 @@ import (
 	"github.com/bio-routing/bio-rd/protocols/bgp/metrics"
 )
 
-const (
-	stateDown        = 0
-	stateIdle        = 1
-	stateConnect     = 2
-	stateActive      = 3
-	stateOpenSent    = 4
-	stateOpenConfirm = 5
-	stateEstablished = 6
-)
-
 type metricsService struct {
 	server *bgpServer
 }
@@ -51,7 +41,7 @@ func (b *metricsService) metricsForPeer(peer *peer) *metrics.BGPPeerMetrics {
 
 	fsm := fsms[0]
 	m.State = b.statusFromFSM(fsm)
-	m.Up = m.State == stateEstablished
+	m.Up = m.State == metrics.StateEstablished
 
 	if m.Up {
 		m.Since = fsm.establishedTime
@@ -83,18 +73,18 @@ func (b *metricsService) metricsForFamily(family *fsmAddressFamily) *metrics.BGP
 func (b *metricsService) statusFromFSM(fsm *FSM) uint8 {
 	switch fsm.state.(type) {
 	case *idleState:
-		return stateIdle
+		return metrics.StateIdle
 	case *connectState:
-		return stateConnect
+		return metrics.StateConnect
 	case *activeState:
-		return stateActive
+		return metrics.StateActive
 	case *openSentState:
-		return stateOpenSent
+		return metrics.StateOpenSent
 	case *openConfirmState:
-		return stateOpenConfirm
+		return metrics.StateOpenConfirm
 	case *establishedState:
-		return stateEstablished
+		return metrics.StateEstablished
 	}
 
-	return stateDown
+	return metrics.StateDown
 }

--- a/protocols/bgp/server/metrics_service_test.go
+++ b/protocols/bgp/server/metrics_service_test.go
@@ -57,7 +57,7 @@ func TestMetrics(t *testing.T) {
 						UpdatesSent:     4,
 						VRF:             "inet.0",
 						Up:              true,
-						State:           stateEstablished,
+						State:           metrics.StateEstablished,
 						Since:           establishedTime,
 						AddressFamilies: []*metrics.BGPAddressFamilyMetrics{
 							{
@@ -95,7 +95,7 @@ func TestMetrics(t *testing.T) {
 						ASN:      202739,
 						LocalASN: 201701,
 						VRF:      "inet.0",
-						State:    stateIdle,
+						State:    metrics.StateIdle,
 						AddressFamilies: []*metrics.BGPAddressFamilyMetrics{
 							{
 								AFI:  packet.IPv4AFI,
@@ -128,7 +128,7 @@ func TestMetrics(t *testing.T) {
 						ASN:      202739,
 						LocalASN: 201701,
 						VRF:      "inet.0",
-						State:    stateActive,
+						State:    metrics.StateActive,
 						AddressFamilies: []*metrics.BGPAddressFamilyMetrics{
 							{
 								AFI:  packet.IPv4AFI,
@@ -161,7 +161,7 @@ func TestMetrics(t *testing.T) {
 						ASN:      202739,
 						LocalASN: 201701,
 						VRF:      "inet.0",
-						State:    stateOpenSent,
+						State:    metrics.StateOpenSent,
 						AddressFamilies: []*metrics.BGPAddressFamilyMetrics{
 							{
 								AFI:  packet.IPv4AFI,
@@ -194,7 +194,7 @@ func TestMetrics(t *testing.T) {
 						ASN:      202739,
 						LocalASN: 201701,
 						VRF:      "inet.0",
-						State:    stateOpenConfirm,
+						State:    metrics.StateOpenConfirm,
 						AddressFamilies: []*metrics.BGPAddressFamilyMetrics{
 							{
 								AFI:  packet.IPv4AFI,
@@ -227,7 +227,7 @@ func TestMetrics(t *testing.T) {
 						ASN:      202739,
 						LocalASN: 201701,
 						VRF:      "inet.0",
-						State:    stateConnect,
+						State:    metrics.StateConnect,
 						AddressFamilies: []*metrics.BGPAddressFamilyMetrics{
 							{
 								AFI:  packet.IPv4AFI,


### PR DESCRIPTION
This enables users of the bio-rd library to reuse the state numbering.
Otherwise users have to maintain their own constats to avoid magic
numbers.