### PR TITLE
Fix alignment issue on arm

### DIFF
--- a/protocols/bgp/server/fsm.go
+++ b/protocols/bgp/server/fsm.go
@@ -37,6 +37,8 @@ type state interface {
 
 // FSM implements the BGP finite state machine (RFC4271)
 type FSM struct {
+	counters fsmCounters
+
 	isBMP       bool
 	peer        *peer
 	eventCh     chan int
@@ -78,7 +80,6 @@ type FSM struct {
 	active     bool
 
 	establishedTime time.Time
-	counters        fsmCounters
 
 	connectionCancelFunc context.CancelFunc
 }


### PR DESCRIPTION
Fixes:
```
INFO[0000] FSM: Neighbor state change                    last_state=openConfirm new_state=established peer=10.80.200.135 reason="Received KEEPALIVE"
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x12354]

goroutine 51 [running]:
runtime/internal/atomic.goXadd64(0x29a20d4, 0x1, 0x0, 0x0, 0x406ad0)
        /usr/lib/go-1.11/src/runtime/internal/atomic/atomic_arm.go:96 +0x1c
github.com/bio-routing/bio-rd/protocols/bgp/server.(*establishedState).update(0x2995e9c, 0x2926f20, 0x2884c90, 0x0, 0x0, 0x8e0f8)
        /home/pi/bio-rd/protocols/bgp/server/fsm_established.go:200 +0x3c
github.com/bio-routing/bio-rd/protocols/bgp/server.(*establishedState).msgReceived(0x2995e9c, 0x29b6000, 0x1000, 0x1000, 0x2995df8, 0xc, 0x2966460, 0x47d820, 0x28f6400)
        /home/pi/bio-rd/protocols/bgp/server/fsm_established.go:183 +0x20c
github.com/bio-routing/bio-rd/protocols/bgp/server.establishedState.run(0x29a2000, 0x40000000, 0x0, 0x0, 0xc0000000)
        /home/pi/bio-rd/protocols/bgp/server/fsm_established.go:55 +0x20c
github.com/bio-routing/bio-rd/protocols/bgp/server.(*FSM).run(0x29a2000)
        /home/pi/bio-rd/protocols/bgp/server/fsm.go:209 +0xa0
created by github.com/bio-routing/bio-rd/protocols/bgp/server.(*bgpServer).incomingConnectionWorker
        /home/pi/bio-rd/protocols/bgp/server/server.go:183 +0x314
```