### PR TITLE
BGP: Validate NLRI (valid Prefix)

### DIFF
--- a/protocols/bgp/packet/helper.go
+++ b/protocols/bgp/packet/helper.go
@@ -39,5 +39,10 @@ func deserializePrefix(b []byte, pfxLen uint8, afi uint16) (*bnet.Prefix, error)
 		return nil, err
 	}
 
-	return bnet.NewPfx(ip, pfxLen).Dedup(), nil
+	pfx := bnet.NewPfx(ip, pfxLen)
+	if !pfx.Valid() {
+		return nil, fmt.Errorf("Invalid prefix: %q", pfx.String())
+	}
+
+	return pfx.Dedup(), nil
 }


### PR DESCRIPTION
This change is here to validate received prefixes.
We had issues using BIO as a BMP receiver with a JUNOS bug that caused BGP add path NLRIs to be interpreted without taking the add path ID into account. Thus IDs have been interpreted as NLRIs causing invalid prefixes to end up in tables. In these cases I think decoding should fail if it's evident something completely invalid happens here.