### PR TITLE
Fix BMP label names/combinations

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -69,6 +69,7 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v1.0.0 h1:vrDKnkGzuGvhNAL56c7DBz29ZL+KxnoR0x7enabFceM=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
+github.com/prometheus/client_golang v1.6.0 h1:YVPodQOcK15POxhgARIvnDRVpLcuK8mglnMrWfyrw6A=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90 h1:S/YWwWx/RA8rT8tKFRuGUZhuA90OyIBpPCXkcbwU8DE=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=

--- a/metrics/bgp/adapter/prom/bgp_prom_adapter.go
+++ b/metrics/bgp/adapter/prom/bgp_prom_adapter.go
@@ -44,7 +44,7 @@ func init() {
 	updatesReceivedDesc = prometheus.NewDesc(prefix+"update_received_count", "Number of updates received", labels, nil)
 	updatesSentDesc = prometheus.NewDesc(prefix+"update_sent_count", "Number of updates sent", labels, nil)
 
-	labelsRouter := append(labels, "router")
+	labelsRouter := append(labels, "sys_name", "agent_address")
 	upDescRouter = prometheus.NewDesc(prefix+"up", "Returns if the session is up", labelsRouter, nil)
 	stateDescRouter = prometheus.NewDesc(prefix+"state", "State of the BGP session (Down = 0, Idle = 1, Connect = 2, Active = 3, OpenSent = 4, OpenConfirm = 5, Established = 6)", labelsRouter, nil)
 	uptimeDescRouter = prometheus.NewDesc(prefix+"uptime_second", "Time since the session was established in seconds", labelsRouter, nil)
@@ -138,13 +138,14 @@ func collectForPeer(ch chan<- prometheus.Metric, peer *metrics.BGPPeerMetrics) {
 	}
 }
 
-func CollectForPeerRouter(ch chan<- prometheus.Metric, rtr string, peer *metrics.BGPPeerMetrics) {
+func CollectForPeerRouter(ch chan<- prometheus.Metric, sysName string, agentAddress string, peer *metrics.BGPPeerMetrics) {
 	l := []string{
 		peer.IP.String(),
 		strconv.Itoa(int(peer.LocalASN)),
 		strconv.Itoa(int(peer.ASN)),
 		peer.VRF,
-		rtr,
+		sysName,
+		agentAddress,
 	}
 
 	var up float64

--- a/metrics/bmp/adapter/prom/bmp_prom_adapter.go
+++ b/metrics/bmp/adapter/prom/bmp_prom_adapter.go
@@ -27,7 +27,7 @@ var (
 )
 
 func init() {
-	labels := []string{"router"}
+	labels := []string{"sys_name", "agent_address"}
 
 	bmpSessionEstablishedDesc = prometheus.NewDesc(prefix+"session_established", "Indicates if a BMP session is established", labels, nil)
 	routeMonitoringMessagesDesc = prometheus.NewDesc(prefix+"route_monitoring_messages", "Returns number of received route monitoring messages", labels, nil)
@@ -78,7 +78,7 @@ func (c *bmpCollector) Collect(ch chan<- prometheus.Metric) {
 }
 
 func (c *bmpCollector) collectForRouter(ch chan<- prometheus.Metric, rtr *metrics.BMPRouterMetrics) {
-	l := []string{rtr.Name}
+	l := []string{rtr.SysName, rtr.Address.String()}
 
 	established := 0
 	if rtr.Established {
@@ -95,10 +95,10 @@ func (c *bmpCollector) collectForRouter(ch chan<- prometheus.Metric, rtr *metric
 	ch <- prometheus.MustNewConstMetric(routeMirroringMessages, prometheus.CounterValue, float64(rtr.RouteMirroringMessages), l...)
 
 	for _, vrfMetric := range rtr.VRFMetrics {
-		vrf_prom.CollectForVRFRouter(ch, rtr.Name, vrfMetric)
+		vrf_prom.CollectForVRFRouter(ch, rtr.SysName, rtr.Address.String(), vrfMetric)
 	}
 
 	for _, peerMetric := range rtr.PeerMetrics {
-		bgp_prom.CollectForPeerRouter(ch, rtr.Name, peerMetric)
+		bgp_prom.CollectForPeerRouter(ch, rtr.SysName, rtr.Address.String(), peerMetric)
 	}
 }

--- a/metrics/vrf/adapter/prom/vrf_prom_adapter.go
+++ b/metrics/vrf/adapter/prom/vrf_prom_adapter.go
@@ -20,7 +20,7 @@ var (
 func init() {
 	labels := []string{"vrf", "rib", "afi", "safi"}
 	routeCountDesc = prometheus.NewDesc(prefix+"route_count", "Number of routes in the RIB", labels, nil)
-	routeCountDescRouter = prometheus.NewDesc(prefix+"route_count", "Number of routes in the RIB", append([]string{"router"}, labels...), nil)
+	routeCountDescRouter = prometheus.NewDesc(prefix+"route_count", "Number of routes in the RIB", append([]string{"sys_name", "agent_address"}, labels...), nil)
 }
 
 // NewCollector creates a new collector instance for the given BGP server
@@ -60,9 +60,9 @@ func (c *vrfCollector) collectForVRF(ch chan<- prometheus.Metric, v *metrics.VRF
 }
 
 // CollectForVRFRouter collects metrics for a certain router (used by BMP Server)
-func CollectForVRFRouter(ch chan<- prometheus.Metric, rtr string, v *metrics.VRFMetrics) {
+func CollectForVRFRouter(ch chan<- prometheus.Metric, sysName string, agentAddress string, v *metrics.VRFMetrics) {
 	for _, rib := range v.RIBs {
 		ch <- prometheus.MustNewConstMetric(routeCountDescRouter, prometheus.GaugeValue, float64(rib.RouteCount),
-			rtr, v.Name, rib.Name, strconv.Itoa(int(rib.AFI)), strconv.Itoa(int(rib.SAFI)))
+			sysName, agentAddress, v.Name, rib.Name, strconv.Itoa(int(rib.AFI)), strconv.Itoa(int(rib.SAFI)))
 	}
 }

--- a/protocols/bgp/metrics/bmp_metrics.go
+++ b/protocols/bgp/metrics/bmp_metrics.go
@@ -1,6 +1,8 @@
 package metrics
 
 import (
+	"net"
+
 	vrf_metrics "github.com/bio-routing/bio-rd/routingtable/vrf/metrics"
 )
 
@@ -11,8 +13,11 @@ type BMPMetrics struct {
 
 // BMPRouterMetrics contains a routers BMP metrics
 type BMPRouterMetrics struct {
-	// Name of the monitored routers
-	Name string
+	// Routers IP Address
+	Address net.IP
+
+	// SysName of the monitored router
+	SysName string
 
 	// Status of TCP session
 	Established bool

--- a/protocols/bgp/server/bmp_metrics_service.go
+++ b/protocols/bgp/server/bmp_metrics_service.go
@@ -33,7 +33,8 @@ func (b *bmpMetricsService) metricsForRouter(rtr *Router) *metrics.BMPRouterMetr
 	established := atomic.LoadUint32(&rtr.established)
 
 	rm := &metrics.BMPRouterMetrics{
-		Name:                         rtr.name,
+		Address:                      rtr.address,
+		SysName:                      rtr.name,
 		Established:                  established == 1,
 		RouteMonitoringMessages:      atomic.LoadUint64(&rtr.counters.routeMonitoringMessages),
 		StatisticsReportMessages:     atomic.LoadUint64(&rtr.counters.statisticsReportMessages),


### PR DESCRIPTION
Currently metrics are identified by their "router=XXX" label. Unfortunately while a BMP session is down that value is the empty string. When multiple BMP sessions are not established the prometheus library fails to expose the metrics because of metrics duplicates. I'm adding the "agent_address" label here und change the "router" label to "sys_name" to make clear that names comes from the BMP Init message.