### PR TITLE
Add functions to AdjRIBIn/AdjRIBOut for RIS

### DIFF
--- a/routingtable/adjRIBIn/adj_rib_in.go
+++ b/routingtable/adjRIBIn/adj_rib_in.go
@@ -254,6 +254,11 @@ func (a *AdjRIBIn) Register(client routingtable.RouteTableClient) {
 	a.clientManager.RegisterWithOptions(client, routingtable.ClientOptions{BestOnly: true})
 }
 
+// RegisterWithOptions registers a client for updates
+func (a *AdjRIBIn) RegisterWithOptions(client routingtable.RouteTableClient, options routingtable.ClientOptions) {
+	a.clientManager.RegisterWithOptions(client, options)
+}
+
 // Unregister unregisters a client
 func (a *AdjRIBIn) Unregister(client routingtable.RouteTableClient) {
 	if !a.clientManager.Unregister(client) {
@@ -270,4 +275,19 @@ func (a *AdjRIBIn) Unregister(client routingtable.RouteTableClient) {
 // RefreshRoute is here to fultill an interface
 func (a *AdjRIBIn) RefreshRoute(*net.Prefix, []*route.Path) {
 
+}
+
+// LPM performs a longest prefix match on the routing table
+func (a *AdjRIBIn) LPM(pfx *net.Prefix) (res []*route.Route) {
+	return a.rt.LPM(pfx)
+}
+
+// Get gets a route
+func (a *AdjRIBIn) Get(pfx *net.Prefix) *route.Route {
+	return a.rt.Get(pfx)
+}
+
+// GetLonger gets all more specifics
+func (a *AdjRIBIn) GetLonger(pfx *net.Prefix) (res []*route.Route) {
+	return a.rt.GetLonger(pfx)
 }

--- a/routingtable/adjRIBOut/adj_rib_out.go
+++ b/routingtable/adjRIBOut/adj_rib_out.go
@@ -275,6 +275,11 @@ func (a *AdjRIBOut) Register(client routingtable.RouteTableClient) {
 	a.clientManager.RegisterWithOptions(client, routingtable.ClientOptions{BestOnly: true})
 }
 
+// RegisterWithOptions registers a client for updates
+func (a *AdjRIBOut) RegisterWithOptions(client routingtable.RouteTableClient, options routingtable.ClientOptions) {
+	a.clientManager.RegisterWithOptions(client, options)
+}
+
 // Unregister unregisters a client
 func (a *AdjRIBOut) Unregister(client routingtable.RouteTableClient) {
 	a.clientManager.Unregister(client)
@@ -329,4 +334,19 @@ func (a *AdjRIBOut) RefreshRoute(pfx *net.Prefix, ribPaths []*route.Path) {
 		}
 
 	}
+}
+
+// LPM performs a longest prefix match on the routing table
+func (a *AdjRIBOut) LPM(pfx *net.Prefix) (res []*route.Route) {
+	return a.rt.LPM(pfx)
+}
+
+// Get gets a route
+func (a *AdjRIBOut) Get(pfx *net.Prefix) *route.Route {
+	return a.rt.Get(pfx)
+}
+
+// GetLonger gets all more specifics
+func (a *AdjRIBOut) GetLonger(pfx *net.Prefix) (res []*route.Route) {
+	return a.rt.GetLonger(pfx)
 }


### PR DESCRIPTION
These functions are required so AdjRIBIn and AdjRIBOut can be used the
same way as LocRIB. With this we can treat the RIB of a BMP server the
same way as the RIB of a BGP server.

---
To use the RIB of BMP and BGP in RIS I need to extend this interface. There is also the option of putting the Interface into the RIS or adding another interface to the routingtable package. In any case we would need to add `Get()`, `LPM()` and `GetLonger()` to be exposed.

I'm very open for input on this one.