### PR TITLE
Accept all rfc4486 bgp error codes

### DIFF
--- a/protocols/bgp/packet/bgp.go
+++ b/protocols/bgp/packet/bgp.go
@@ -88,7 +88,7 @@ const (
 	PeerDeconfigured              = 3
 	AdminReset                    = 4
 	ConnectionRejected            = 5
-	OtherConfigChange             = 8
+	OtherConfigChange             = 6
 	ConnectionCollisionResolution = 7
 	OutOfResources                = 8
 

--- a/protocols/bgp/packet/decoder.go
+++ b/protocols/bgp/packet/decoder.go
@@ -115,7 +115,8 @@ func decodeNotificationMsg(buf *bytes.Buffer) (*BGPNotification, error) {
 			return invalidErrCode(msg)
 		}
 	case Cease:
-		if !(msg.ErrorSubcode == 0 || msg.ErrorSubcode == AdministrativeShutdown || msg.ErrorSubcode == AdministrativeReset) {
+		// accept 0 or all error subcodes specified in RFC4486 (1 - 8)
+		if msg.ErrorSubcode > OutOfResources {
 			return invalidErrCode(msg)
 		}
 	default:

--- a/protocols/bgp/packet/decoder_test.go
+++ b/protocols/bgp/packet/decoder_test.go
@@ -387,7 +387,7 @@ func TestDecodeNotificationMsg(t *testing.T) {
 		},
 		{
 			name:     "Cease (invalid subcode)",
-			input:    []byte{6, 1},
+			input:    []byte{6, 9},
 			wantFail: true,
 		},
 	}


### PR DESCRIPTION
I've tested this stuff with FRR-7.3. FRR sends out ConnectionCollisionResolution and OtherConfigChange in my tests, bio wasn't to happy about it, but now it looks good.