### PR TITLE
Handle multiple next-hops in NLRI

### DIFF
--- a/protocols/bgp/packet/mp_reach_nlri.go
+++ b/protocols/bgp/packet/mp_reach_nlri.go
@@ -64,7 +64,12 @@ func deserializeMultiProtocolReachNLRI(b []byte, opt *DecodeOptions) (MultiProto
 			fmt.Errorf("Failed to decode next hop IP: expected %d bytes for NLRI, only %d remaining", nextHopLength, budget)
 	}
 
-	nh, err := bnet.IPFromBytes(variable[:nextHopLength])
+	firstNextHopLength := nextHopLength
+	if nextHopLength == 32 {
+		// second next-hop is lladdr (see rfc2545 sec 3 par 2)
+		firstNextHopLength = 16
+	}
+	nh, err := bnet.IPFromBytes(variable[:firstNextHopLength])
 	if err != nil {
 		return MultiProtocolReachNLRI{}, errors.Wrap(err, "Failed to decode next hop IP")
 	}

--- a/protocols/bgp/packet/path_attributes_test.go
+++ b/protocols/bgp/packet/path_attributes_test.go
@@ -956,6 +956,29 @@ func TestDecodeMultiProtocolReachNLRI(t *testing.T) {
 			},
 		},
 		{
+			name: "valid MP_REACH_NLRI with two next-hops",
+			input: []byte{
+				0x00, 0x02, // AFI
+				0x01,                                                                                                 // SAFI
+				0x20, 0x20, 0x01, 0x06, 0x78, 0x01, 0xe0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, // NextHop
+				0xfe, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, // Link Local NextHop
+				0x00,                                     // RESERVED
+				0x30, 0x26, 0x00, 0x00, 0x06, 0xff, 0x05, // Prefix
+			},
+			opt: &DecodeOptions{},
+			expected: &PathAttribute{
+				Length: 44,
+				Value: MultiProtocolReachNLRI{
+					AFI:     IPv6AFI,
+					SAFI:    UnicastSAFI,
+					NextHop: bnet.IPv6FromBlocks(0x2001, 0x678, 0x1e0, 0, 0, 0, 0, 0x2).Ptr(),
+					NLRI: &NLRI{
+						Prefix: bnet.NewPfx(bnet.IPv6FromBlocks(0x2600, 0x6, 0xff05, 0, 0, 0, 0, 0), 48).Ptr(),
+					},
+				},
+			},
+		},
+		{
 			name: "MP_REACH_NLRI with invalid length",
 			input: []byte{
 				0x00, 0x02, // AFI


### PR DESCRIPTION
RFC2545 section 3 paragraph 2 allows for a next-hop field length of 32.
In this case two IPv6 addresses are being sent, first the global
address, then the link local address. For now we are just ignoring the
link local address and parsing only the first.

Without this patch Bio will not be able to talk to BGP spekaders using
this features. An UPDATE mesage containing such a next-hop field would
result in the following error:

Failed to decode BGP message: Failed to decode message: Unable to decode path attr: Failed to multi protocol reachable NLRI: Unable to decode MP_REACH_NLRI: Failed to decode next hop IP: byte slice has an invalid length. Expected either 4 (IPv4) or 16 (IPv6) bytes but got: 32