### PR TITLE
Fix crash on route withdrawal with addpath

### DIFF
--- a/routingtable/adjRIBIn/adj_rib_in.go
+++ b/routingtable/adjRIBIn/adj_rib_in.go
@@ -220,7 +220,7 @@ func (a *AdjRIBIn) removePath(pfx *net.Prefix, p *route.Path) bool {
 	oldPaths := r.Paths()
 	for _, path := range oldPaths {
 		if a.addPathRX {
-			if path.BGPPath.PathIdentifier != p.BGPPath.PathIdentifier {
+			if p != nil && path.BGPPath.PathIdentifier != p.BGPPath.PathIdentifier {
 				continue
 			}
 		}


### PR DESCRIPTION
If addpath is enabled rx then `adjRIBIn.RemovePath()` will access a member
of p. As p might be nil (e.g. called by `fsm_address_family withdraw()`)
we need to check for this before accessing it.
---
Test missing, input on that would be welcome. Also I'm not sure if this is the right way to fix this or if there would be a point before this were we'd need to handle this.

For reference, here is the stacktrace I got:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x922412]

goroutine 9 [running]:
github.com/bio-routing/bio-rd/routingtable/adjRIBIn.(*AdjRIBIn).removePath(0xc000d105a0, 0xc000b888a0, 0x0, 0xc000a42001)
	/home/seba/projects/src/bio-rd/routingtable/adjRIBIn/adj_rib_in.go:240 +0x242
github.com/bio-routing/bio-rd/routingtable/adjRIBIn.(*AdjRIBIn).RemovePath(0xc000d105a0, 0xc000b888a0, 0x0, 0x5eb89500)
	/home/seba/projects/src/bio-rd/routingtable/adjRIBIn/adj_rib_in.go:225 +0x89
github.com/bio-routing/bio-rd/protocols/bgp/server.(*fsmAddressFamily).withdraws(0xc0001e4000, 0xc000a9a030)
	/home/seba/projects/src/bio-rd/protocols/bgp/server/fsm_address_family.go:150 +0x56
github.com/bio-routing/bio-rd/protocols/bgp/server.(*fsmAddressFamily).processUpdate(0xc0001e4000, 0xc000a9a030)
	/home/seba/projects/src/bio-rd/protocols/bgp/server/fsm_address_family.go:143 +0x63
github.com/bio-routing/bio-rd/protocols/bgp/server.(*establishedState).update(0xc000b51db0, 0xc000a9a030, 0xc000a420c0, 0x0, 0x0, 0xc00012e6c0)
	/home/seba/projects/src/bio-rd/protocols/bgp/server/fsm_established.go:207 +0x28c
github.com/bio-routing/bio-rd/protocols/bgp/server.(*establishedState).msgReceived(0xc000b51db0, 0xc0001f7000, 0x1000, 0x1000, 0xc000a96003, 0xc5d1c0, 0xc000b8b3d0, 0x0, 0x0)
	/home/seba/projects/src/bio-rd/protocols/bgp/server/fsm_established.go:183 +0x27e
github.com/bio-routing/bio-rd/protocols/bgp/server.establishedState.run(0xc0000342c0, 0xc5d1c0, 0xc0000bc178, 0x0, 0x0)
	/home/seba/projects/src/bio-rd/protocols/bgp/server/fsm_established.go:55 +0x300
github.com/bio-routing/bio-rd/protocols/bgp/server.(*FSM).run(0xc0000342c0)
	/home/seba/projects/src/bio-rd/protocols/bgp/server/fsm.go:211 +0xc2
created by github.com/bio-routing/bio-rd/protocols/bgp/server.(*bgpServer).incomingConnectionWorker
	/home/seba/projects/src/bio-rd/protocols/bgp/server/server.go:183 +0x492
```