### PR TITLE
Replace paths with same identifier with AddPath

### DIFF
--- a/protocols/bgp/server/fsm_address_family.go
+++ b/protocols/bgp/server/fsm_address_family.go
@@ -155,6 +155,7 @@ func (f *fsmAddressFamily) updates(u *packet.BGPUpdate) {
 	for r := u.NLRI; r != nil; r = r.Next {
 		path := f.newRoutePath()
 		f.processAttributes(u.PathAttributes, path)
+		path.BGPPath.PathIdentifier = u.NLRI.PathIdentifier
 
 		f.adjRIBIn.AddPath(r.Prefix, path)
 	}
@@ -191,6 +192,7 @@ func (f *fsmAddressFamily) multiProtocolUpdate(path *route.Path, nlri packet.Mul
 		return
 	}
 
+	path.BGPPath.PathIdentifier = nlri.NLRI.PathIdentifier
 	path.BGPPath.BGPPathA.NextHop = nlri.NextHop
 
 	for n := nlri.NLRI; n != nil; n = n.Next {
@@ -201,6 +203,10 @@ func (f *fsmAddressFamily) multiProtocolUpdate(path *route.Path, nlri packet.Mul
 func (f *fsmAddressFamily) multiProtocolWithdraw(path *route.Path, nlri packet.MultiProtocolUnreachNLRI) {
 	if f.afi != nlri.AFI || f.safi != nlri.SAFI {
 		return
+	}
+
+	if nlri.NLRI != nil {
+		path.BGPPath.PathIdentifier = nlri.NLRI.PathIdentifier
 	}
 
 	for cur := nlri.NLRI; cur != nil; cur = cur.Next {

--- a/routingtable/adjRIBIn/adj_rib_in_test.go
+++ b/routingtable/adjRIBIn/adj_rib_in_test.go
@@ -136,16 +136,22 @@ func TestAddPath(t *testing.T) {
 				route.NewRoute(net.NewPfx(net.IPv4FromOctets(10, 0, 0, 0), 8).Ptr(), &route.Path{
 					Type: route.BGPPathType,
 					BGPPath: &route.BGPPath{
+						PathIdentifier: 10,
 						BGPPathA: &route.BGPPathA{
 							LocalPref: 100,
+							NextHop:   net.IPv4FromOctets(20, 0, 0, 0).Ptr(),
+							Source:    net.IPv4FromOctets(20, 0, 0, 0).Ptr(),
 						},
 					},
 				}),
 				route.NewRoute(net.NewPfx(net.IPv4FromOctets(10, 0, 0, 0), 8).Ptr(), &route.Path{
 					Type: route.BGPPathType,
 					BGPPath: &route.BGPPath{
+						PathIdentifier: 20,
 						BGPPathA: &route.BGPPathA{
 							LocalPref: 200,
+							NextHop:   net.IPv4FromOctets(20, 0, 0, 0).Ptr(),
+							Source:    net.IPv4FromOctets(20, 0, 0, 0).Ptr(),
 						},
 					},
 				}),
@@ -157,16 +163,67 @@ func TestAddPath(t *testing.T) {
 					{
 						Type: route.BGPPathType,
 						BGPPath: &route.BGPPath{
+							PathIdentifier: 10,
 							BGPPathA: &route.BGPPathA{
 								LocalPref: 100,
+								NextHop:   net.IPv4FromOctets(20, 0, 0, 0).Ptr(),
+								Source:    net.IPv4FromOctets(20, 0, 0, 0).Ptr(),
 							},
 						},
 					},
 					{
 						Type: route.BGPPathType,
 						BGPPath: &route.BGPPath{
+							PathIdentifier: 20,
 							BGPPathA: &route.BGPPathA{
 								LocalPref: 200,
+								NextHop:   net.IPv4FromOctets(20, 0, 0, 0).Ptr(),
+								Source:    net.IPv4FromOctets(20, 0, 0, 0).Ptr(),
+							},
+						},
+					},
+				}),
+			},
+		},
+		{
+			name:    "Add route (with BGP add path) twice",
+			addPath: false,
+			routes: []*route.Route{
+				route.NewRoute(net.NewPfx(net.IPv4FromOctets(10, 0, 0, 0), 8).Ptr(), &route.Path{
+					Type: route.BGPPathType,
+					BGPPath: &route.BGPPath{
+						PathIdentifier: 10,
+						BGPPathA: &route.BGPPathA{
+							LocalPref: 100,
+							NextHop:   net.IPv4FromOctets(20, 0, 0, 0).Ptr(),
+							Source:    net.IPv4FromOctets(20, 0, 0, 0).Ptr(),
+						},
+					},
+				}),
+				route.NewRoute(net.NewPfx(net.IPv4FromOctets(10, 0, 0, 0), 8).Ptr(), &route.Path{
+					Type: route.BGPPathType,
+					BGPPath: &route.BGPPath{
+						PathIdentifier: 10,
+						BGPPathA: &route.BGPPathA{
+							LocalPref: 200,
+							NextHop:   net.IPv4FromOctets(20, 0, 0, 0).Ptr(),
+							Source:    net.IPv4FromOctets(20, 0, 0, 0).Ptr(),
+						},
+					},
+				}),
+			},
+			removePfx:  nil,
+			removePath: nil,
+			expected: []*route.Route{
+				route.NewRouteAddPath(net.NewPfx(net.IPv4FromOctets(10, 0, 0, 0), 8).Ptr(), []*route.Path{
+					{
+						Type: route.BGPPathType,
+						BGPPath: &route.BGPPath{
+							PathIdentifier: 10,
+							BGPPathA: &route.BGPPathA{
+								LocalPref: 200,
+								NextHop:   net.IPv4FromOctets(20, 0, 0, 0).Ptr(),
+								Source:    net.IPv4FromOctets(20, 0, 0, 0).Ptr(),
 							},
 						},
 					},


### PR DESCRIPTION
RFC7911 sec 5 par 1 sais that the path identifier added by BGP Add Path
uniquely identifies a path for a given prefix. Therefore, when a new
path arrives we need to replace all paths with the same path identifier
for this prefix. Ignoring this leads to routes piling up in the
adjRIBIn.