### PR TITLE
Export neighbors in bmp server

### DIFF
--- a/protocols/bgp/server/bmp_neighbor_manager.go
+++ b/protocols/bgp/server/bmp_neighbor_manager.go
@@ -6,17 +6,17 @@ import (
 )
 
 type neighborManager struct {
-	neighbors   []*neighbor
+	neighbors   []*Neighbor
 	neighborsMu sync.Mutex
 }
 
 func newNeighborManager() *neighborManager {
 	return &neighborManager{
-		neighbors: make([]*neighbor, 0),
+		neighbors: make([]*Neighbor, 0),
 	}
 }
 
-func (nm *neighborManager) addNeighbor(n *neighbor) error {
+func (nm *neighborManager) addNeighbor(n *Neighbor) error {
 	nm.neighborsMu.Lock()
 	defer nm.neighborsMu.Unlock()
 
@@ -30,7 +30,7 @@ func (nm *neighborManager) addNeighbor(n *neighbor) error {
 	return nil
 }
 
-func (nm *neighborManager) getNeighbor(vrfID uint64, addr [16]byte) *neighbor {
+func (nm *neighborManager) getNeighbor(vrfID uint64, addr [16]byte) *Neighbor {
 	nm.neighborsMu.Lock()
 	defer nm.neighborsMu.Unlock()
 
@@ -80,11 +80,11 @@ func (nm *neighborManager) disposeAll() {
 	}
 }
 
-func (nm *neighborManager) list() []*neighbor {
+func (nm *neighborManager) list() []*Neighbor {
 	nm.neighborsMu.Lock()
 	defer nm.neighborsMu.Unlock()
 
-	ret := make([]*neighbor, len(nm.neighbors))
+	ret := make([]*Neighbor, len(nm.neighbors))
 	for i := range nm.neighbors {
 		ret[i] = nm.neighbors[i]
 	}

--- a/protocols/bgp/server/bmp_router.go
+++ b/protocols/bgp/server/bmp_router.go
@@ -104,6 +104,11 @@ func (r *Router) Address() net.IP {
 	return r.address
 }
 
+// Neighbors lists all neighbors
+func (r *Router) Neighbors() []*Neighbor {
+	return r.neighborManager.list()
+}
+
 func (r *Router) serve(con net.Conn) {
 	r.con = con
 	r.runMu.Lock()

--- a/protocols/bgp/server/bmp_router.go
+++ b/protocols/bgp/server/bmp_router.go
@@ -55,7 +55,8 @@ type routerCounters struct {
 	routeMirroringMessages       uint64
 }
 
-type neighbor struct {
+// Neighbor represents a bgp neighbor of a router
+type Neighbor struct {
 	vrfID       uint64
 	peerAddress [16]byte
 	localAS     uint32
@@ -335,7 +336,7 @@ func (r *Router) processPeerUpNotification(msg *bmppkt.PeerUpNotification) error
 	openSent.openMsgReceived(recvOpen)
 
 	fsm.state = newEstablishedState(fsm)
-	n := &neighbor{
+	n := &Neighbor{
 		vrfID:       msg.PerPeerHeader.PeerDistinguisher,
 		localAS:     fsm.peer.localASN,
 		peerAS:      msg.PerPeerHeader.PeerAS,
@@ -357,7 +358,7 @@ func (r *Router) processPeerUpNotification(msg *bmppkt.PeerUpNotification) error
 	return nil
 }
 
-func (n *neighbor) registerClients(clients map[afiClient]struct{}) {
+func (n *Neighbor) registerClients(clients map[afiClient]struct{}) {
 	for ac := range clients {
 		if ac.afi == packet.IPv4AFI {
 			n.fsm.ipv4Unicast.adjRIBIn.Register(ac.client)


### PR DESCRIPTION
I'm thinking about exposing the neighbors of a bmp session (and a bgp server later on). Neighbors needs to be public for that. Haven't tested it yet but wanted to ask you upstream people for an early opinion.