### PR TITLE
WIP: Get merge Adj-RIB-In into Loc-RIB

### DIFF
--- a/route/path.go
+++ b/route/path.go
@@ -13,6 +13,7 @@ type Path struct {
 	StaticPath *StaticPath
 	BGPPath    *BGPPath
 	FIBPath    *FIBPath
+	Hidden     bool
 }
 
 // Select returns negative if p < q, 0 if paths are equal, positive if p > q
@@ -25,6 +26,14 @@ func (p *Path) Select(q *Path) int8 {
 	case q == nil:
 		return 1
 	default:
+	}
+
+	if p.Hidden && !q.Hidden {
+		return 1
+	}
+
+	if !p.Hidden && q.Hidden {
+		return -1
 	}
 
 	if p.Type > q.Type {

--- a/route/path_test.go
+++ b/route/path_test.go
@@ -176,6 +176,42 @@ func TestSelect(t *testing.T) {
 			},
 			expected: 0,
 		},
+		{
+			name: "Hidden path #1",
+			p: &Path{
+				Type: BGPPathType,
+				BGPPath: &BGPPath{
+					BGPPathA: NewBGPPathA(),
+				},
+				Hidden: true,
+			},
+			q: &Path{
+				Type: BGPPathType,
+				BGPPath: &BGPPath{
+					BGPPathA: NewBGPPathA(),
+				},
+				Hidden: false,
+			},
+			expected: 1,
+		},
+		{
+			name: "Hidden path #2",
+			p: &Path{
+				Type: BGPPathType,
+				BGPPath: &BGPPath{
+					BGPPathA: NewBGPPathA(),
+				},
+				Hidden: false,
+			},
+			q: &Path{
+				Type: BGPPathType,
+				BGPPath: &BGPPath{
+					BGPPathA: NewBGPPathA(),
+				},
+				Hidden: true,
+			},
+			expected: -1,
+		},
 	}
 
 	for _, test := range tests {

--- a/route/route.go
+++ b/route/route.go
@@ -296,9 +296,18 @@ func (r *Route) updateEqualPathCount() {
 		return
 	}
 
+	if r.paths[0].Hidden {
+		r.ecmpPaths = 1
+		return
+	}
+
 	count := uint(1)
 	for i := 0; i < len(r.paths)-1; i++ {
 		if !r.paths[i].ECMP(r.paths[i+1]) {
+			break
+		}
+
+		if r.paths[i].Hidden {
 			break
 		}
 		count++
@@ -332,4 +341,15 @@ func (r *Route) Print() string {
 	}
 
 	return ret
+}
+
+// Hidden returns true when all paths of the route are hidden
+func (r *Route) Hidden() bool {
+	for _, p := range r.paths {
+		if !p.Hidden {
+			return false
+		}
+	}
+
+	return true
 }


### PR DESCRIPTION
Let's move the Adj-RIB-In responsibility into the Loc-RIB in order to get rid of redundant tries. This will safe both memory and CPU cycles (currently used by the GC).