### PR TITLE
Tear down ObserveRIB streaming RPC when RIB is destroyed

### DIFF
--- a/cmd/ris/risserver/rib_client.go
+++ b/cmd/ris/risserver/rib_client.go
@@ -1,0 +1,73 @@
+package risserver
+
+import (
+	pb "github.com/bio-routing/bio-rd/cmd/ris/api"
+	"github.com/bio-routing/bio-rd/net"
+	"github.com/bio-routing/bio-rd/route"
+	routeapi "github.com/bio-routing/bio-rd/route/api"
+)
+
+type update struct {
+	advertisement bool
+	prefix        net.Prefix
+	path          *route.Path
+}
+
+type ribClient struct {
+	fifo    *updateFIFO
+	stopped chan struct{}
+}
+
+func newRIBClient(fifo *updateFIFO) *ribClient {
+	return &ribClient{
+		fifo:    fifo,
+		stopped: make(chan struct{}),
+	}
+}
+
+func (r *ribClient) AddPath(pfx *net.Prefix, path *route.Path) error {
+	return r.addPath(pfx, path, false)
+}
+
+func (r *ribClient) AddPathInitialDump(pfx *net.Prefix, path *route.Path) error {
+	return r.addPath(pfx, path, true)
+}
+
+func (r *ribClient) addPath(pfx *net.Prefix, path *route.Path, isInitalDump bool) error {
+	r.fifo.queue(&pb.RIBUpdate{
+		Advertisement: true,
+		IsInitialDump: isInitalDump,
+		Route: &routeapi.Route{
+			Pfx: pfx.ToProto(),
+			Paths: []*routeapi.Path{
+				path.ToProto(),
+			},
+		},
+	})
+
+	return nil
+}
+
+func (r *ribClient) RemovePath(pfx *net.Prefix, path *route.Path) bool {
+	r.fifo.queue(&pb.RIBUpdate{
+		Advertisement: false,
+		Route: &routeapi.Route{
+			Pfx: pfx.ToProto(),
+			Paths: []*routeapi.Path{
+				path.ToProto(),
+			},
+		},
+	})
+
+	return false
+}
+
+func (r *ribClient) RefreshRoute(*net.Prefix, []*route.Path) {}
+
+// ReplacePath is here to fulfill an interface
+func (r *ribClient) ReplacePath(*net.Prefix, *route.Path, *route.Path) {}
+
+// Destroy stopps the ribClient. This is triggered when a BMP connection is lost so we can drop subscribed clients.
+func (r *ribClient) Destroy() {
+	close(r.stopped)
+}

--- a/cmd/ris/risserver/rib_client.go
+++ b/cmd/ris/risserver/rib_client.go
@@ -67,7 +67,7 @@ func (r *ribClient) RefreshRoute(*net.Prefix, []*route.Path) {}
 // ReplacePath is here to fulfill an interface
 func (r *ribClient) ReplacePath(*net.Prefix, *route.Path, *route.Path) {}
 
-// Destroy stopps the ribClient. This is triggered when a BMP connection is lost so we can drop subscribed clients.
-func (r *ribClient) Destroy() {
+// Dispose stopps the ribClient. This is triggered when a BMP connection is lost so we can drop subscribed clients.
+func (r *ribClient) Dispose() {
 	close(r.stopped)
 }

--- a/protocols/bgp/server/bmp_router.go
+++ b/protocols/bgp/server/bmp_router.go
@@ -135,7 +135,7 @@ func (r *Router) serve(con net.Conn) error {
 }
 
 func (r *Router) cleanup() {
-	r.vrfRegistry.UnregisterAll()
+	r.vrfRegistry.DisposeAll()
 	r.neighborManager.disposeAll()
 }
 

--- a/protocols/bgp/server/update_sender.go
+++ b/protocols/bgp/server/update_sender.go
@@ -388,3 +388,6 @@ func (a *UpdateSender) ReplacePath(*net.Prefix, *route.Path, *route.Path) {
 func (a *UpdateSender) RefreshRoute(*net.Prefix, []*route.Path) {
 
 }
+
+// Dispose is here to fulfill an interface
+func (u *UpdateSender) Dispose() {}

--- a/protocols/kernel/kernel.go
+++ b/protocols/kernel/kernel.go
@@ -82,6 +82,3 @@ func (k *Kernel) ReplacePath(*net.Prefix, *route.Path, *route.Path) {
 func (k *Kernel) RefreshRoute(*net.Prefix, []*route.Path) {
 
 }
-
-// Destroy is here to fulfill an interface (needed for BMP use case)
-func (k *Kernel) Destroy() {}

--- a/protocols/kernel/kernel.go
+++ b/protocols/kernel/kernel.go
@@ -82,3 +82,6 @@ func (k *Kernel) ReplacePath(*net.Prefix, *route.Path, *route.Path) {
 func (k *Kernel) RefreshRoute(*net.Prefix, []*route.Path) {
 
 }
+
+// Destroy is here to fulfill an interface (needed for BMP use case)
+func (k *Kernel) Destroy() {}

--- a/routingtable/adjRIBOut/adj_rib_out.go
+++ b/routingtable/adjRIBOut/adj_rib_out.go
@@ -354,3 +354,8 @@ func (a *AdjRIBOut) Get(pfx *net.Prefix) *route.Route {
 func (a *AdjRIBOut) GetLonger(pfx *net.Prefix) (res []*route.Route) {
 	return a.rt.GetLonger(pfx)
 }
+
+// Destroy is here to fulfill an interface
+func (a *AdjRIBOut) Destroy() {
+
+}

--- a/routingtable/adjRIBOut/adj_rib_out.go
+++ b/routingtable/adjRIBOut/adj_rib_out.go
@@ -355,7 +355,6 @@ func (a *AdjRIBOut) GetLonger(pfx *net.Prefix) (res []*route.Route) {
 	return a.rt.GetLonger(pfx)
 }
 
-// Destroy is here to fulfill an interface
-func (a *AdjRIBOut) Destroy() {
-
-}
+// Dispose is here to fulfill an interface. We don't care if the RIB we're registred to
+// as a client is gone as this only happens in the BMP use case where AdjRIBOut is not used.
+func (a *AdjRIBOut) Dispose() {}

--- a/routingtable/client_interface.go
+++ b/routingtable/client_interface.go
@@ -13,7 +13,8 @@ type RouteTableClient interface {
 	RemovePath(*net.Prefix, *route.Path) bool
 	ReplacePath(*net.Prefix, *route.Path, *route.Path)
 	RefreshRoute(*net.Prefix, []*route.Path)
-	Destroy()
+	// A call to Dispose() signals that no more updates are to be expected from the RIB the client is registered to.
+	Dispose()
 }
 
 type AdjRIB interface {
@@ -38,5 +39,6 @@ type AdjRIBOut interface {
 	AddPathInitialDump(pfx *net.Prefix, path *route.Path) error
 	ReplacePath(*net.Prefix, *route.Path, *route.Path)
 	RefreshRoute(*net.Prefix, []*route.Path)
-	Destroy()
+	// A call to Dispose() signals that no more updates are to be expected from the RIB the client is registered to.
+	Dispose()
 }

--- a/routingtable/client_interface.go
+++ b/routingtable/client_interface.go
@@ -13,6 +13,7 @@ type RouteTableClient interface {
 	RemovePath(*net.Prefix, *route.Path) bool
 	ReplacePath(*net.Prefix, *route.Path, *route.Path)
 	RefreshRoute(*net.Prefix, []*route.Path)
+	Destroy()
 }
 
 type AdjRIB interface {
@@ -37,4 +38,5 @@ type AdjRIBOut interface {
 	AddPathInitialDump(pfx *net.Prefix, path *route.Path) error
 	ReplacePath(*net.Prefix, *route.Path, *route.Path)
 	RefreshRoute(*net.Prefix, []*route.Path)
+	Destroy()
 }

--- a/routingtable/client_manager_test.go
+++ b/routingtable/client_manager_test.go
@@ -61,7 +61,7 @@ func (m MockClient) RefreshRoute(*net.Prefix, []*route.Path) {
 
 }
 
-func (m MockClient) Destroy() {
+func (m MockClient) Dispose() {
 
 }
 

--- a/routingtable/client_manager_test.go
+++ b/routingtable/client_manager_test.go
@@ -61,6 +61,10 @@ func (m MockClient) RefreshRoute(*net.Prefix, []*route.Path) {
 
 }
 
+func (m MockClient) Destroy() {
+
+}
+
 func TestClients(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/routingtable/locRIB/loc_rib.go
+++ b/routingtable/locRIB/loc_rib.go
@@ -344,3 +344,10 @@ func (a *LocRIB) ReplaceFilterChain(filter.Chain) {
 func (a *LocRIB) RefreshRoute(*net.Prefix, []*route.Path) {
 
 }
+
+// Destroy tells all clients that this LocRIB is not to be used anymore (this can happen when RIS loses a BMP connection)
+func (a *LocRIB) Destroy() {
+	for _, c := range a.clientManager.Clients() {
+		c.Destroy()
+	}
+}

--- a/routingtable/locRIB/loc_rib.go
+++ b/routingtable/locRIB/loc_rib.go
@@ -345,9 +345,9 @@ func (a *LocRIB) RefreshRoute(*net.Prefix, []*route.Path) {
 
 }
 
-// Destroy tells all clients that this LocRIB is not to be used anymore (this can happen when RIS loses a BMP connection)
-func (a *LocRIB) Destroy() {
+// Dispose tells all clients that this LocRIB is not to be used anymore (this can happen when RIS loses a BMP connection)
+func (a *LocRIB) Dispose() {
 	for _, c := range a.clientManager.Clients() {
-		c.Destroy()
+		c.Dispose()
 	}
 }

--- a/routingtable/mock_client.go
+++ b/routingtable/mock_client.go
@@ -82,4 +82,4 @@ func (m *RTMockClient) ReplaceFilterChain(filter.Chain) {}
 
 func (m *RTMockClient) ReplacePath(*net.Prefix, *route.Path, *route.Path) {}
 
-func (m *RTMockClient) Destroy() {}
+func (m *RTMockClient) Dispose() {}

--- a/routingtable/mock_client.go
+++ b/routingtable/mock_client.go
@@ -81,3 +81,5 @@ func (m *RTMockClient) RefreshRoute(*net.Prefix, []*route.Path) {}
 func (m *RTMockClient) ReplaceFilterChain(filter.Chain) {}
 
 func (m *RTMockClient) ReplacePath(*net.Prefix, *route.Path, *route.Path) {}
+
+func (m *RTMockClient) Destroy() {}

--- a/routingtable/vrf/vrf_registry.go
+++ b/routingtable/vrf/vrf_registry.go
@@ -66,7 +66,7 @@ func (r *VRFRegistry) DisposeAll() {
 
 	for id := range r.vrfs {
 		for _, rib := range r.vrfs[id].ribs {
-			rib.Destroy()
+			rib.Dispose()
 		}
 		delete(r.vrfs, id)
 	}

--- a/routingtable/vrf/vrf_registry.go
+++ b/routingtable/vrf/vrf_registry.go
@@ -59,12 +59,15 @@ func (r *VRFRegistry) UnregisterVRF(v *VRF) {
 	delete(r.vrfs, v.routeDistinguisher)
 }
 
-// UnregisterAll unregisters all VRFs
-func (r *VRFRegistry) UnregisterAll() {
+// DisposeAll dosposes all VRFs
+func (r *VRFRegistry) DisposeAll() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	for id := range r.vrfs {
+		for _, rib := range r.vrfs[id].ribs {
+			rib.Destroy()
+		}
 		delete(r.vrfs, id)
 	}
 }


### PR DESCRIPTION
Background: After a router went down all routes have been withdrawn as expected to all clients currently running the ObserveRIB gRPC. However, the BMP server creates fresh VRFs and RIBs when a BMP session comes back up.
Thus the running ObserveRIB calls were using stale RIB references and in the end not sending any new routes received via BMP to the running ObserveRIB clients. It is better to just detect this situation and end the RPC so clients can reconnect and get information from the current RIB.