### PR TITLE
Add test for as_path.go + repair String()

### DIFF
--- a/protocols/bgp/types/as_path.go
+++ b/protocols/bgp/types/as_path.go
@@ -1,7 +1,8 @@
 package types
 
 import (
-	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/bio-routing/bio-rd/route/api"
 )
@@ -154,28 +155,32 @@ func ASPathFromProtoASPath(segments []*api.ASPathSegment) *ASPath {
 }
 
 // String converts an ASPath to it's human redable representation
-func (pa *ASPath) String() (ret string) {
-	if pa == nil {
+func (a *ASPath) String() string {
+	if a == nil {
 		return ""
 	}
-	for _, p := range *pa {
-		if p.Type == ASSet {
-			ret += " ("
-		}
-		n := len(p.ASNs)
-		for i, asn := range p.ASNs {
-			if i < n-1 {
-				ret += fmt.Sprintf("%d ", asn)
-				continue
+
+	parts := make([]string, 0)
+
+	for _, p := range *a {
+		if p.Type == ASSequence {
+			for _, asn := range p.ASNs {
+				parts = append(parts, strconv.Itoa(int(asn)))
 			}
-			ret += fmt.Sprintf("%d", asn)
+
+			continue
 		}
+
 		if p.Type == ASSet {
-			ret += ")"
+			setParts := make([]string, len(p.ASNs))
+			for i, asn := range p.ASNs {
+				setParts[i] = strconv.Itoa(int(asn))
+			}
+			parts = append(parts, "("+strings.Join(setParts, " ")+")")
 		}
 	}
 
-	return
+	return strings.Join(parts, " ")
 }
 
 // Length returns the AS path length as used by path selection

--- a/protocols/bgp/types/as_path_test.go
+++ b/protocols/bgp/types/as_path_test.go
@@ -1,0 +1,373 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/bio-routing/bio-rd/route/api"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestASPathCompare(t *testing.T) {
+	var a *ASPath
+	var b *ASPath
+	assert.True(t, a.Compare(b))
+
+	a = &ASPath{}
+	assert.False(t, a.Compare(b))
+
+	a = nil
+	b = &ASPath{}
+	assert.False(t, a.Compare(b))
+
+	a = &ASPath{
+		ASPathSegment{
+			Type: ASSet,
+			ASNs: []uint32{1, 2},
+		},
+		ASPathSegment{
+			Type: ASSequence,
+			ASNs: []uint32{3, 4},
+		},
+	}
+
+	bEqual := &ASPath{
+		ASPathSegment{
+			Type: ASSet,
+			ASNs: []uint32{1, 2},
+		},
+		ASPathSegment{
+			Type: ASSequence,
+			ASNs: []uint32{3, 4},
+		},
+	}
+
+	assert.True(t, a.Compare(bEqual))
+
+	bDifferentLength := &ASPath{
+		ASPathSegment{
+			Type: ASSequence,
+			ASNs: []uint32{3, 5},
+		},
+	}
+
+	assert.False(t, a.Compare(bDifferentLength))
+
+	bDifferent := &ASPath{
+		ASPathSegment{
+			Type: ASSequence,
+			ASNs: []uint32{1, 2},
+		},
+		ASPathSegment{
+			Type: ASSequence,
+			ASNs: []uint32{3, 5},
+		},
+	}
+
+	assert.False(t, a.Compare(bDifferent))
+}
+
+func TestASPathGetFirstSequenceSegment(t *testing.T) {
+	a := &ASPath{
+		ASPathSegment{
+			Type: ASSet,
+			ASNs: []uint32{1, 2},
+		},
+		ASPathSegment{
+			Type: ASSequence,
+			ASNs: []uint32{3, 5},
+		},
+		ASPathSegment{
+			Type: ASSequence,
+			ASNs: []uint32{5, 6},
+		},
+	}
+
+	actual := a.GetFirstSequenceSegment()
+	expected := &ASPathSegment{
+		Type: ASSequence,
+		ASNs: []uint32{3, 5},
+	}
+	assert.Equal(t, expected, actual)
+}
+
+func TestASPathGetFirstSequenceSegmentNoASSequence(t *testing.T) {
+	a := &ASPath{
+		ASPathSegment{
+			Type: ASSet,
+			ASNs: []uint32{1, 2},
+		},
+		ASPathSegment{
+			Type: ASSet,
+			ASNs: []uint32{2, 2},
+		},
+	}
+
+	actual := a.GetFirstSequenceSegment()
+	assert.Nil(t, actual)
+}
+
+func TestASPathGetFirstSequenceSegmentEmpty(t *testing.T) {
+	a := &ASPath{}
+
+	actual := a.GetFirstSequenceSegment()
+	assert.Nil(t, actual)
+}
+
+func TestASPathGetLastSequenceSegment(t *testing.T) {
+	a := &ASPath{
+		ASPathSegment{
+			Type: ASSet,
+			ASNs: []uint32{1, 2},
+		},
+		ASPathSegment{
+			Type: ASSequence,
+			ASNs: []uint32{3, 5},
+		},
+		ASPathSegment{
+			Type: ASSequence,
+			ASNs: []uint32{5, 6},
+		},
+		ASPathSegment{
+			Type: ASSet,
+			ASNs: []uint32{3, 5},
+		},
+	}
+
+	actual := a.GetLastSequenceSegment()
+	expected := &ASPathSegment{
+		Type: ASSequence,
+		ASNs: []uint32{5, 6},
+	}
+	assert.Equal(t, expected, actual)
+}
+
+func TestASPathGetLastSequenceSegmentNone(t *testing.T) {
+	a := &ASPath{
+		ASPathSegment{
+			Type: ASSet,
+			ASNs: []uint32{3, 5},
+		},
+	}
+
+	actual := a.GetLastSequenceSegment()
+	assert.Nil(t, actual)
+}
+
+func TestASPathSegmentGetFirstASN(t *testing.T) {
+	s := ASPathSegment{
+		Type: ASSet,
+		ASNs: []uint32{3, 5},
+	}
+
+	assert.Equal(t, uint32(3), *s.GetFirstASN())
+}
+
+func TestASPathSegmentGetFirstASNEmpty(t *testing.T) {
+	s := ASPathSegment{
+		Type: ASSet,
+		ASNs: []uint32{},
+	}
+
+	assert.Nil(t, s.GetFirstASN())
+}
+
+func TestASPathSegmentGetLastASN(t *testing.T) {
+	s := ASPathSegment{
+		Type: ASSet,
+		ASNs: []uint32{3, 5},
+	}
+
+	assert.Equal(t, uint32(5), *s.GetLastASN())
+}
+
+func TestASPathSegmentGetLastASNEmpty(t *testing.T) {
+	s := ASPathSegment{
+		Type: ASSet,
+		ASNs: []uint32{},
+	}
+
+	assert.Nil(t, s.GetLastASN())
+}
+
+func TestASPathSegmentCompareDifferentType(t *testing.T) {
+	a := ASPathSegment{
+		Type: ASSet,
+		ASNs: []uint32{3, 5},
+	}
+
+	b := ASPathSegment{
+		Type: ASSequence,
+		ASNs: []uint32{3, 5},
+	}
+
+	assert.False(t, a.Compare(b))
+}
+
+func TestASPathSegmentCompareDifferentLengthASNs(t *testing.T) {
+	a := ASPathSegment{
+		Type: ASSequence,
+		ASNs: []uint32{1, 3, 5},
+	}
+
+	b := ASPathSegment{
+		Type: ASSequence,
+		ASNs: []uint32{3, 5},
+	}
+
+	assert.False(t, a.Compare(b))
+}
+
+func TestASPathSegmentCompareDifferentASNs(t *testing.T) {
+	a := ASPathSegment{
+		Type: ASSequence,
+		ASNs: []uint32{3, 4},
+	}
+
+	b := ASPathSegment{
+		Type: ASSequence,
+		ASNs: []uint32{3, 5},
+	}
+
+	assert.False(t, a.Compare(b))
+}
+
+func TestASPathSegmentCompareSame(t *testing.T) {
+	a := ASPathSegment{
+		Type: ASSequence,
+		ASNs: []uint32{3, 5},
+	}
+
+	b := ASPathSegment{
+		Type: ASSequence,
+		ASNs: []uint32{3, 5},
+	}
+
+	assert.True(t, a.Compare(b))
+}
+
+func TestASPathToProto(t *testing.T) {
+	a := ASPath{
+		ASPathSegment{
+			Type: ASSequence,
+			ASNs: []uint32{3, 4},
+		},
+		ASPathSegment{
+			Type: ASSet,
+			ASNs: []uint32{1, 2},
+		},
+	}
+	actual := a.ToProto()
+
+	expected := make([]*api.ASPathSegment, 2, 2)
+	expected[0] = &api.ASPathSegment{
+		AsSequence: true,
+		Asns:       []uint32{3, 4},
+	}
+	expected[1] = &api.ASPathSegment{
+		AsSequence: false,
+		Asns:       []uint32{1, 2},
+	}
+
+	assert.Equal(t, expected, actual)
+}
+
+func TestASPathFromProtoASPath(t *testing.T) {
+	p := make([]*api.ASPathSegment, 2, 2)
+	p[0] = &api.ASPathSegment{
+		AsSequence: true,
+		Asns:       []uint32{3, 4},
+	}
+	p[1] = &api.ASPathSegment{
+		AsSequence: false,
+		Asns:       []uint32{1, 2},
+	}
+
+	actual := ASPathFromProtoASPath(p)
+
+	expected := &ASPath{
+		ASPathSegment{
+			Type: ASSequence,
+			ASNs: []uint32{3, 4},
+		},
+		ASPathSegment{
+			Type: ASSet,
+			ASNs: []uint32{1, 2},
+		},
+	}
+
+	assert.Equal(t, expected, actual)
+}
+
+func TestASPathString(t *testing.T) {
+	tests := []struct {
+		name     string
+		asPath   *ASPath
+		expected string
+	}{
+		{
+			name: "test two Sequences + one Set",
+			asPath: &ASPath{
+				ASPathSegment{
+					Type: ASSequence,
+					ASNs: []uint32{3, 4},
+				},
+
+				ASPathSegment{
+					Type: ASSequence,
+					ASNs: []uint32{5, 62},
+				},
+				ASPathSegment{
+					Type: ASSet,
+					ASNs: []uint32{100, 2},
+				},
+			},
+			expected: "3 4 5 62 (100 2)",
+		}, {
+			name: "test one Set",
+			asPath: &ASPath{
+				ASPathSegment{
+					Type: ASSet,
+					ASNs: []uint32{1, 2},
+				},
+			},
+			expected: "(1 2)",
+		}, {
+			name:     "test empty",
+			asPath:   &ASPath{},
+			expected: "",
+		},
+	}
+
+	for _, test := range tests {
+
+		actual := test.asPath.String()
+		assert.Equal(t, test.expected, actual, test.name)
+	}
+}
+
+func TestASPathStringNil(t *testing.T) {
+	var a *ASPath
+	actual := a.String()
+	assert.Empty(t, actual)
+}
+
+func TestASPathLength(t *testing.T) {
+	a := &ASPath{
+		ASPathSegment{
+			Type: ASSequence,
+			ASNs: []uint32{3, 4},
+		},
+
+		ASPathSegment{
+			Type: ASSequence,
+			ASNs: []uint32{5, 6},
+		},
+		ASPathSegment{
+			Type: ASSet,
+			ASNs: []uint32{1, 2},
+		},
+	}
+
+	actual := a.Length()
+	assert.Equal(t, uint16(5), actual)
+}


### PR DESCRIPTION
Adds test for `protocols/bgp/types/as_path.go`. The `String()` function of `ASPath` was re-implemented because its output was broken: sometimes spaces were missing, or in case it only contained one segment of type `ASSet`, it used to generate a leading space.

The rewrite of the `String` func was reviewed by @taktv6.