### PR TITLE
Migrate to sys/unix, since usage of syscall is not recommended

### DIFF
--- a/net/tcp/listen.go
+++ b/net/tcp/listen.go
@@ -1,10 +1,10 @@
 package tcp
 
 import (
+	"fmt"
 	"net"
-	"syscall"
 
-	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
 )
 
 // Listener listens for TCP clients
@@ -19,59 +19,59 @@ func Listen(laddr *net.TCPAddr, ttl uint8) (*Listener, error) {
 		laddr: laddr,
 	}
 
-	afi := syscall.AF_INET
+	afi := unix.AF_INET
 	if laddr.IP.To4() == nil {
-		afi = syscall.AF_INET6
+		afi = unix.AF_INET6
 	}
 
-	fd, err := syscall.Socket(afi, syscall.SOCK_STREAM, syscall.IPPROTO_TCP)
+	fd, err := unix.Socket(afi, unix.SOCK_STREAM, unix.IPPROTO_TCP)
 	if err != nil {
-		return nil, errors.Wrap(err, "socket() failed")
+		return nil, fmt.Errorf("socket() failed: %w", err)
 	}
 	l.fd = fd
 
-	if afi == syscall.AF_INET6 {
-		err = syscall.SetsockoptInt(fd, syscall.SOL_IPV6, syscall.IPV6_V6ONLY, 1)
+	if afi == unix.AF_INET6 {
+		err = unix.SetsockoptInt(fd, SOL_IPV6, unix.IPV6_V6ONLY, 1)
 		if err != nil {
-			syscall.Close(fd)
-			return nil, errors.Wrap(err, "Unable to set IPV6_V6ONLY")
+			unix.Close(fd)
+			return nil, fmt.Errorf("unable to set IPV6_V6ONLY: %w", err)
 		}
 	}
 
-	err = syscall.SetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1)
+	err = unix.SetsockoptInt(fd, unix.SOL_SOCKET, unix.SO_REUSEADDR, 1)
 	if err != nil {
-		syscall.Close(fd)
-		return nil, errors.Wrap(err, "Unable to get SO_REUSEADDR")
+		unix.Close(fd)
+		return nil, fmt.Errorf("unable to get SO_REUSEADDR %w", err)
 	}
 
 	if ttl != 0 {
-		err = syscall.SetsockoptInt(fd, syscall.SOL_IP, syscall.IP_TTL, int(ttl))
+		err = unix.SetsockoptInt(fd, SOL_IP, unix.IP_TTL, int(ttl))
 		if err != nil {
-			syscall.Close(fd)
-			return nil, errors.Wrap(err, "Unable to set IP_TTL")
+			unix.Close(fd)
+			return nil, fmt.Errorf("unable to set IP_TTL: %w", err)
 		}
 	}
 
 	if laddr.IP.To4() != nil {
-		err = syscall.Bind(fd, &syscall.SockaddrInet4{
+		err = unix.Bind(fd, &unix.SockaddrInet4{
 			Port: laddr.Port,
 			Addr: ipv4AddrToArray(laddr.IP),
 		})
 	} else {
-		err = syscall.Bind(fd, &syscall.SockaddrInet6{
+		err = unix.Bind(fd, &unix.SockaddrInet6{
 			Port: laddr.Port,
 			Addr: ipv6AddrToArray(laddr.IP),
 		})
 	}
 	if err != nil {
-		syscall.Close(fd)
-		return nil, errors.Wrap(err, "bind failed")
+		unix.Close(fd)
+		return nil, fmt.Errorf("bind failed: %w", err)
 	}
 
-	err = syscall.Listen(fd, 128)
+	err = unix.Listen(fd, 128)
 	if err != nil {
-		syscall.Close(fd)
-		return nil, errors.Wrap(err, "listen failed")
+		unix.Close(fd)
+		return nil, fmt.Errorf("listen failed: %w", err)
 	}
 
 	return l, nil
@@ -94,7 +94,7 @@ func (l *Listener) SetTCPMD5(peerAddr net.IP, secret string) error {
 
 // AcceptTCP accepts a new TCP connection
 func (l *Listener) AcceptTCP() (*Conn, error) {
-	fd, sa, err := syscall.Accept(l.fd)
+	fd, sa, err := unix.Accept(l.fd)
 	if err != nil {
 		return nil, err
 	}
@@ -104,13 +104,13 @@ func (l *Listener) AcceptTCP() (*Conn, error) {
 	}
 
 	switch sa.(type) {
-	case *syscall.SockaddrInet4:
-		x := sa.(*syscall.SockaddrInet4)
-		raddr.IP = net.IP(x.Addr[:])
+	case *unix.SockaddrInet4:
+		x := sa.(*unix.SockaddrInet4)
+		raddr.IP = x.Addr[:]
 		raddr.Port = x.Port
-	case *syscall.SockaddrInet6:
-		x := sa.(*syscall.SockaddrInet4)
-		raddr.IP = net.IP(x.Addr[:])
+	case *unix.SockaddrInet6:
+		x := sa.(*unix.SockaddrInet4)
+		raddr.IP = x.Addr[:]
 		raddr.Port = x.Port
 	}
 

--- a/net/tcp/tcp.go
+++ b/net/tcp/tcp.go
@@ -3,10 +3,17 @@ package tcp
 import (
 	"fmt"
 	"net"
-	"syscall"
 	"time"
 
-	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	// SOL_IP is not defined on darwin
+	SOL_IP = 0x0
+
+	// SOL_IPV6 is not defined on darwin
+	SOL_IPV6 = 0x29
 )
 
 // Conn is TCP connection
@@ -22,25 +29,25 @@ func Dial(laddr, raddr *net.TCPAddr, ttl uint8, md5Secret string, noRoute bool) 
 		return nil, fmt.Errorf("raddr is mandatory")
 	}
 
-	afi := uint16(syscall.AF_INET)
+	afi := uint16(unix.AF_INET)
 	if raddr.IP.To4() == nil {
-		afi = syscall.AF_INET6
+		afi = unix.AF_INET6
 	}
 
 	c, err := dialTCP(afi, laddr, raddr, ttl, md5Secret, noRoute)
 	if err != nil {
-		return nil, errors.Wrap(err, "Dialing failed")
+		return nil, fmt.Errorf("dialing failed: %w", err)
 	}
 
 	c.laddr = laddr
 	if c.laddr == nil || c.laddr.IP == nil {
-		sa, err := syscall.Getsockname(c.fd)
+		sa, err := unix.Getsockname(c.fd)
 		if err != nil {
-			return nil, errors.Wrap(err, "getsockname() failed")
+			return nil, fmt.Errorf("getsockname() failed: %w", err)
 		}
 
-		sa4 := sa.(*syscall.SockaddrInet4)
-		c.laddr.IP = net.IP(sa4.Addr[:])
+		sa4 := sa.(*unix.SockaddrInet4)
+		c.laddr.IP = sa4.Addr[:]
 		c.laddr.Port = sa4.Port
 	}
 	c.raddr = raddr
@@ -49,17 +56,17 @@ func Dial(laddr, raddr *net.TCPAddr, ttl uint8, md5Secret string, noRoute bool) 
 
 // Write writes to a TCP connection
 func (c *Conn) Write(b []byte) (n int, err error) {
-	return syscall.Write(c.fd, b)
+	return unix.Write(c.fd, b)
 }
 
 // Read reads from a TCP connection
 func (c *Conn) Read(b []byte) (n int, err error) {
-	return syscall.Read(c.fd, b)
+	return unix.Read(c.fd, b)
 }
 
 // Close closes the connection
 func (c *Conn) Close() error {
-	return syscall.Close(c.fd)
+	return unix.Close(c.fd)
 }
 
 // LocalAddr gets the local address
@@ -74,34 +81,34 @@ func (c *Conn) RemoteAddr() net.Addr {
 
 // SetDeadline is here to fulfill net.Conn interface
 func (c *Conn) SetDeadline(t time.Time) error {
-	return fmt.Errorf("No supported")
+	return fmt.Errorf("not supported")
 }
 
 // SetReadDeadline is here to fulfill net.Conn interface
 func (c *Conn) SetReadDeadline(t time.Time) error {
-	return fmt.Errorf("No supported")
+	return fmt.Errorf("not supported")
 }
 
 // SetWriteDeadline is here to fulfill net.Conn interface
 func (c *Conn) SetWriteDeadline(t time.Time) error {
-	return fmt.Errorf("No supported")
+	return fmt.Errorf("not supported")
 }
 
 // SetTTL sets the TTL on a TCP connection
 func (c *Conn) SetTTL(ttl uint8) error {
 	if c.raddr.IP.To4() != nil {
-		return syscall.SetsockoptInt(c.fd, syscall.SOL_IP, syscall.IP_TTL, int(ttl))
+		return unix.SetsockoptInt(c.fd, SOL_IP, unix.IP_TTL, int(ttl))
 	}
 
-	return syscall.SetsockoptInt(c.fd, syscall.IPPROTO_IPV6, syscall.IPV6_UNICAST_HOPS, int(ttl))
+	return unix.SetsockoptInt(c.fd, unix.IPPROTO_IPV6, unix.IPV6_UNICAST_HOPS, int(ttl))
 }
 
 // SetDontRoute sets the SO_DONTROUTE option
 func (c *Conn) SetDontRoute() error {
-	return syscall.SetsockoptInt(c.fd, syscall.SOL_SOCKET, syscall.SO_DONTROUTE, 1)
+	return unix.SetsockoptInt(c.fd, unix.SOL_SOCKET, unix.SO_DONTROUTE, 1)
 }
 
 // SetNoDelay sets the TCP_NODELAY option
 func (c *Conn) SetNoDelay() error {
-	return syscall.SetsockoptInt(c.fd, syscall.IPPROTO_TCP, syscall.TCP_NODELAY, 1)
+	return unix.SetsockoptInt(c.fd, unix.IPPROTO_TCP, unix.TCP_NODELAY, 1)
 }


### PR DESCRIPTION
Also, use Standard error wrapping. SOL_IP and SOL_IPV6 are defined in tcp.go to allow compilation under Darwin.

See https://pkg.go.dev/syscall