### PR TITLE
bmp: set local ASN to number from capability in case of ASN4

### DIFF
--- a/protocols/bgp/server/bmp_router.go
+++ b/protocols/bgp/server/bmp_router.go
@@ -409,6 +409,10 @@ func (p *peer) configureBySentOpen(msg *packet.BGPOpen) {
 						}
 					}
 				}
+			case packet.ASN4CapabilityCode:
+				if p.localASN == packet.ASTransASN {
+					p.localASN = cap.Value.(packet.ASN4Capability).ASN4
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Otherwise the localASN stays at 23456 and BGPPathA.EBGP is incorrectly reported as external for all routes.