### PR TITLE
Fix a number of go-staticcheck nits

### DIFF
--- a/protocols/bgp/server/bgp_api.go
+++ b/protocols/bgp/server/bgp_api.go
@@ -24,7 +24,7 @@ func NewBGPAPIServer(s BGPServer) *BGPAPIServer {
 }
 
 func (s *BGPAPIServer) ListSessions(ctx context.Context, in *api.ListSessionsRequest) (*api.ListSessionsResponse, error) {
-	return nil, fmt.Errorf("Not implemented yet")
+	return nil, fmt.Errorf("not implemented yet")
 }
 
 // DumpRIBIn dumps the RIB in of a peer for a given AFI/SAFI

--- a/protocols/bgp/server/bmp_metrics_service.go
+++ b/protocols/bgp/server/bmp_metrics_service.go
@@ -3,7 +3,6 @@ package server
 import (
 	"sync/atomic"
 
-	"github.com/bio-routing/bio-rd/protocols/bgp/metrics"
 	bgp_metrics "github.com/bio-routing/bio-rd/protocols/bgp/metrics"
 	"github.com/bio-routing/bio-rd/routingtable/vrf"
 	vrf_metrics "github.com/bio-routing/bio-rd/routingtable/vrf/metrics"
@@ -13,14 +12,14 @@ type bmpMetricsService struct {
 	server *BMPServer
 }
 
-func (b *bmpMetricsService) metrics() *metrics.BMPMetrics {
-	return &metrics.BMPMetrics{
+func (b *bmpMetricsService) metrics() *bgp_metrics.BMPMetrics {
+	return &bgp_metrics.BMPMetrics{
 		Routers: b.routerMetrics(),
 	}
 }
 
-func (b *bmpMetricsService) routerMetrics() []*metrics.BMPRouterMetrics {
-	routers := make([]*metrics.BMPRouterMetrics, 0)
+func (b *bmpMetricsService) routerMetrics() []*bgp_metrics.BMPRouterMetrics {
+	routers := make([]*bgp_metrics.BMPRouterMetrics, 0)
 
 	for _, rtr := range b.server.getRouters() {
 		routers = append(routers, b.metricsForRouter(rtr))
@@ -29,10 +28,10 @@ func (b *bmpMetricsService) routerMetrics() []*metrics.BMPRouterMetrics {
 	return routers
 }
 
-func (b *bmpMetricsService) metricsForRouter(rtr *Router) *metrics.BMPRouterMetrics {
+func (b *bmpMetricsService) metricsForRouter(rtr *Router) *bgp_metrics.BMPRouterMetrics {
 	established := atomic.LoadUint32(&rtr.established)
 
-	rm := &metrics.BMPRouterMetrics{
+	rm := &bgp_metrics.BMPRouterMetrics{
 		Address:                      rtr.address,
 		SysName:                      rtr.name,
 		Established:                  established == 1,

--- a/protocols/bgp/server/bmp_neighbor_manager.go
+++ b/protocols/bgp/server/bmp_neighbor_manager.go
@@ -68,7 +68,7 @@ func (nm *neighborManager) _neighborDown(vrfID uint64, addr [16]byte) error {
 		return nil
 	}
 
-	return fmt.Errorf("Neighbor %d/%v not found", vrfID, addr)
+	return fmt.Errorf("neighbor %d/%v not found", vrfID, addr)
 }
 
 func (nm *neighborManager) disposeAll() {

--- a/protocols/bgp/server/bmp_router.go
+++ b/protocols/bgp/server/bmp_router.go
@@ -277,7 +277,7 @@ func (r *Router) processPeerUpNotification(msg *bmppkt.PeerUpNotification) error
 	}).Infof("peer up notification received")
 
 	if len(msg.SentOpenMsg) < packet.MinOpenLen {
-		return fmt.Errorf("Received peer up notification for %v: Invalid sent open message: %v", msg.PerPeerHeader.PeerAddress, msg.SentOpenMsg)
+		return fmt.Errorf("received peer up notification for %v: Invalid sent open message: %v", msg.PerPeerHeader.PeerAddress, msg.SentOpenMsg)
 	}
 
 	sentOpen, err := packet.DecodeOpenMsg(bytes.NewBuffer(msg.SentOpenMsg[packet.HeaderLen:]))
@@ -286,7 +286,7 @@ func (r *Router) processPeerUpNotification(msg *bmppkt.PeerUpNotification) error
 	}
 
 	if len(msg.ReceivedOpenMsg) < packet.MinOpenLen {
-		return fmt.Errorf("Received peer up notification for %v: Invalid received open message: %v", msg.PerPeerHeader.PeerAddress, msg.ReceivedOpenMsg)
+		return fmt.Errorf("received peer up notification for %v: Invalid received open message: %v", msg.PerPeerHeader.PeerAddress, msg.ReceivedOpenMsg)
 	}
 
 	recvOpen, err := packet.DecodeOpenMsg(bytes.NewBuffer(msg.ReceivedOpenMsg[packet.HeaderLen:]))

--- a/protocols/bgp/server/bmp_server.go
+++ b/protocols/bgp/server/bmp_server.go
@@ -208,7 +208,7 @@ func (b *BMPServer) addRouter(r *Router) {
 	b.routersMu.Lock()
 	defer b.routersMu.Unlock()
 
-	b.routers[fmt.Sprintf("%s", r.address.String())] = r
+	b.routers[r.address.String()] = r
 }
 
 func (b *BMPServer) deleteRouter(addr net.IP) {
@@ -297,7 +297,7 @@ func (b *BMPServer) GetRouter(name string) RouterInterface {
 // Metrics gets BMP server metrics
 func (b *BMPServer) Metrics() (*metrics.BMPMetrics, error) {
 	if b.metrics == nil {
-		return nil, fmt.Errorf("Server not started yet")
+		return nil, fmt.Errorf("server not started yet")
 	}
 
 	return b.metrics.metrics(), nil

--- a/protocols/bgp/server/fsm.go
+++ b/protocols/bgp/server/fsm.go
@@ -171,7 +171,6 @@ func (fsm *FSM) start() {
 
 	go fsm.run()
 	go fsm.tcpConnector(ctx)
-	return
 }
 
 func (fsm *FSM) activate() {

--- a/protocols/bgp/server/fsm_test.go
+++ b/protocols/bgp/server/fsm_test.go
@@ -119,7 +119,6 @@ func TestFSM255UpdatesIPv4(t *testing.T) {
 		}
 
 		fsmA.msgRecvCh <- update
-		ribRouteCount = fsmA.ipv4Unicast.rib.RouteCount()
 	}
 	time.Sleep(time.Second * 1)
 	ribRouteCount = fsmA.ipv4Unicast.rib.RouteCount()
@@ -233,7 +232,6 @@ func TestFSM255UpdatesIPv6(t *testing.T) {
 			64, 0x20, 0x01, 0x06, 0x78, 0x01, 0xe0, 0x0, i,
 		}
 		fsmA.msgRecvCh <- update
-		ribRouteCount = fsmA.ipv6Unicast.rib.RouteCount()
 	}
 	time.Sleep(time.Second * 1)
 

--- a/protocols/bgp/server/peer.go
+++ b/protocols/bgp/server/peer.go
@@ -276,7 +276,7 @@ func newPeer(c PeerConfig, server *bgpServer) (*peer, error) {
 		}
 
 		if p.ipv4.rib == nil {
-			return nil, fmt.Errorf("No RIB for IPv4 unicast configured")
+			return nil, fmt.Errorf("no RIB for IPv4 unicast configured")
 		}
 	}
 
@@ -307,7 +307,7 @@ func newPeer(c PeerConfig, server *bgpServer) (*peer, error) {
 		caps = append(caps, multiProtocolCapability(packet.AFIIPv6))
 
 		if p.ipv6.rib == nil {
-			return nil, fmt.Errorf("No RIB for IPv6 unicast configured")
+			return nil, fmt.Errorf("no RIB for IPv6 unicast configured")
 		}
 	}
 

--- a/protocols/bgp/server/server.go
+++ b/protocols/bgp/server/server.go
@@ -80,7 +80,7 @@ func (b *bgpServer) Start() error {
 		for _, addr := range b.listenAddrs {
 			l, err := NewTCPListener(addr, acceptCh)
 			if err != nil {
-				return fmt.Errorf("Failed to start TCPListener for %s: %w", addr, err)
+				return fmt.Errorf("failed to start TCPListener for %s: %w", addr, err)
 			}
 			b.listeners = append(b.listeners, l)
 		}
@@ -96,7 +96,7 @@ func (b *bgpServer) Start() error {
 func (b *bgpServer) ReplaceImportFilterChain(peerIP *bnet.IP, c filter.Chain) error {
 	p := b.peers.get(peerIP)
 	if p == nil {
-		return fmt.Errorf("Peer %q not found", peerIP.String())
+		return fmt.Errorf("peer %q not found", peerIP.String())
 	}
 
 	p.replaceImportFilterChain(c)
@@ -107,7 +107,7 @@ func (b *bgpServer) ReplaceImportFilterChain(peerIP *bnet.IP, c filter.Chain) er
 func (b *bgpServer) ReplaceExportFilterChain(peerIP *bnet.IP, c filter.Chain) error {
 	p := b.peers.get(peerIP)
 	if p == nil {
-		return fmt.Errorf("Peer %q not found", peerIP.String())
+		return fmt.Errorf("peer %q not found", peerIP.String())
 	}
 
 	p.replaceExportFilterChain(c)
@@ -242,14 +242,14 @@ func (b *bgpServer) DisposePeer(addr *bnet.IP) {
 		return
 	}
 
-	log.Infof("Disposing BGP session with %s", addr.String())
+	log.Infof("disposing BGP session with %s", addr.String())
 	p.stop()
 	b.peers.remove(addr)
 }
 
 func (b *bgpServer) Metrics() (*metrics.BGPMetrics, error) {
 	if b.metrics == nil {
-		return nil, fmt.Errorf("Server not started yet")
+		return nil, fmt.Errorf("server not started yet")
 	}
 
 	return b.metrics.metrics(), nil

--- a/protocols/bgp/server/update_helper.go
+++ b/protocols/bgp/server/update_helper.go
@@ -18,7 +18,7 @@ func serializeAndSendUpdate(out io.Writer, update serializeAbleUpdate, opt *pack
 
 	_, err = out.Write(updateBytes)
 	if err != nil {
-		return fmt.Errorf("Failed sending Update: %w", err)
+		return fmt.Errorf("failed sending Update: %w", err)
 	}
 	return nil
 }

--- a/protocols/bgp/server/update_helper_test.go
+++ b/protocols/bgp/server/update_helper_test.go
@@ -72,7 +72,7 @@ func TestSerializeAndSendUpdate(t *testing.T) {
 		{
 			name: "failed connection",
 			buf:  &failingReadWriter{},
-			err:  errors.New("Failed sending Update: general error"),
+			err:  errors.New("failed sending Update: general error"),
 			testUpdate: &packet.BGPUpdate{
 				WithdrawnRoutesLen: 5,
 				WithdrawnRoutes: &packet.NLRI{

--- a/protocols/bgp/server/update_sender.go
+++ b/protocols/bgp/server/update_sender.go
@@ -8,7 +8,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/bio-routing/bio-rd/net"
 	bnet "github.com/bio-routing/bio-rd/net"
 	"github.com/bio-routing/bio-rd/protocols/bgp/packet"
 	"github.com/bio-routing/bio-rd/route"
@@ -383,12 +382,12 @@ func (a *UpdateSender) ReplaceFilterChain(c filter.Chain) {
 }
 
 // ReplacePath is here to fulfill an interface
-func (a *UpdateSender) ReplacePath(*net.Prefix, *route.Path, *route.Path) {
+func (a *UpdateSender) ReplacePath(*bnet.Prefix, *route.Path, *route.Path) {
 
 }
 
 // RefreshRoute is here to fultill an interface
-func (a *UpdateSender) RefreshRoute(*net.Prefix, []*route.Path) {
+func (a *UpdateSender) RefreshRoute(*bnet.Prefix, []*route.Path) {
 
 }
 


### PR DESCRIPTION
 * Make sure error messages starting lower case
 * Consolidate double imports
 * Remove redundant return/fmt.Sprintf calls
 * Remove unused variables from tests