### PR TITLE
WIP: Clean up some existing parameter passing (and prepare AdjRIBOut for OTC validation)

### DIFF
--- a/protocols/bgp/server/bgp_api_test.go
+++ b/protocols/bgp/server/bgp_api_test.go
@@ -67,7 +67,7 @@ func TestDumpRIBInOut(t *testing.T) {
 									0: {
 										ipv4Unicast: &fsmAddressFamily{
 											adjRIBIn:  adjRIBIn.New(filter.NewAcceptAllFilterChain(), nil, &peerInfo),
-											adjRIBOut: adjRIBOut.New(nil, &routingtable.PeerInfo{Type: route.BGPPathType}, filter.NewAcceptAllFilterChain(), true),
+											adjRIBOut: adjRIBOut.New(nil, &routingtable.PeerInfo{Type: route.BGPPathType, AddPathTX: true}, filter.NewAcceptAllFilterChain()),
 										},
 									},
 								},
@@ -97,7 +97,7 @@ func TestDumpRIBInOut(t *testing.T) {
 									0: {
 										ipv4Unicast: &fsmAddressFamily{
 											adjRIBIn:  adjRIBIn.New(filter.NewAcceptAllFilterChain(), nil, &peerInfo),
-											adjRIBOut: adjRIBOut.New(nil, &routingtable.PeerInfo{Type: route.BGPPathType, RouteServerClient: true, PeerIP: bnet.IPv4(0).Ptr()}, filter.NewAcceptAllFilterChain(), false),
+											adjRIBOut: adjRIBOut.New(nil, &routingtable.PeerInfo{Type: route.BGPPathType, RouteServerClient: true, PeerIP: bnet.IPv4(0).Ptr(), AddPathTX: false}, filter.NewAcceptAllFilterChain()),
 										},
 									},
 								},
@@ -146,7 +146,7 @@ func TestDumpRIBInOut(t *testing.T) {
 			wantFail: false,
 		},
 		{
-			name: "Test #3: One complex routes given",
+			name: "Test #3: One complex route given",
 			apisrv: &BGPAPIServer{
 				srv: &bgpServer{
 					peers: &peerManager{
@@ -157,7 +157,7 @@ func TestDumpRIBInOut(t *testing.T) {
 									0: {
 										ipv4Unicast: &fsmAddressFamily{
 											adjRIBIn:  adjRIBIn.New(filter.NewAcceptAllFilterChain(), routingtable.NewContributingASNs(), &peerInfo),
-											adjRIBOut: adjRIBOut.New(nil, &routingtable.PeerInfo{Type: route.BGPPathType, RouteServerClient: true, PeerIP: bnet.IPv4(123).Ptr()}, filter.NewAcceptAllFilterChain(), false),
+											adjRIBOut: adjRIBOut.New(nil, &routingtable.PeerInfo{Type: route.BGPPathType, RouteServerClient: true, PeerIP: bnet.IPv4(123).Ptr(), AddPathTX: false}, filter.NewAcceptAllFilterChain()),
 										},
 									},
 								},

--- a/protocols/bgp/server/bgp_api_test.go
+++ b/protocols/bgp/server/bgp_api_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestDumpRIBInOut(t *testing.T) {
-	peerParams := adjRIBIn.PeerParameters{
+	peerInfo := routingtable.PeerInfo{
 		RouterID:  0,
 		ClusterID: 0,
 		AddPathRX: true,
@@ -66,8 +66,8 @@ func TestDumpRIBInOut(t *testing.T) {
 								fsms: []*FSM{
 									0: {
 										ipv4Unicast: &fsmAddressFamily{
-											adjRIBIn:  adjRIBIn.New(filter.NewAcceptAllFilterChain(), nil, peerParams),
-											adjRIBOut: adjRIBOut.New(nil, &routingtable.Neighbor{Type: route.BGPPathType}, filter.NewAcceptAllFilterChain(), true),
+											adjRIBIn:  adjRIBIn.New(filter.NewAcceptAllFilterChain(), nil, &peerInfo),
+											adjRIBOut: adjRIBOut.New(nil, &routingtable.PeerInfo{Type: route.BGPPathType}, filter.NewAcceptAllFilterChain(), true),
 										},
 									},
 								},
@@ -96,8 +96,8 @@ func TestDumpRIBInOut(t *testing.T) {
 								fsms: []*FSM{
 									0: {
 										ipv4Unicast: &fsmAddressFamily{
-											adjRIBIn:  adjRIBIn.New(filter.NewAcceptAllFilterChain(), nil, peerParams),
-											adjRIBOut: adjRIBOut.New(nil, &routingtable.Neighbor{Type: route.BGPPathType, RouteServerClient: true, Address: bnet.IPv4(0).Ptr()}, filter.NewAcceptAllFilterChain(), false),
+											adjRIBIn:  adjRIBIn.New(filter.NewAcceptAllFilterChain(), nil, &peerInfo),
+											adjRIBOut: adjRIBOut.New(nil, &routingtable.PeerInfo{Type: route.BGPPathType, RouteServerClient: true, PeerIP: bnet.IPv4(0).Ptr()}, filter.NewAcceptAllFilterChain(), false),
 										},
 									},
 								},
@@ -156,8 +156,8 @@ func TestDumpRIBInOut(t *testing.T) {
 								fsms: []*FSM{
 									0: {
 										ipv4Unicast: &fsmAddressFamily{
-											adjRIBIn:  adjRIBIn.New(filter.NewAcceptAllFilterChain(), routingtable.NewContributingASNs(), peerParams),
-											adjRIBOut: adjRIBOut.New(nil, &routingtable.Neighbor{Type: route.BGPPathType, RouteServerClient: true, Address: bnet.IPv4(123).Ptr()}, filter.NewAcceptAllFilterChain(), false),
+											adjRIBIn:  adjRIBIn.New(filter.NewAcceptAllFilterChain(), routingtable.NewContributingASNs(), &peerInfo),
+											adjRIBOut: adjRIBOut.New(nil, &routingtable.PeerInfo{Type: route.BGPPathType, RouteServerClient: true, PeerIP: bnet.IPv4(123).Ptr()}, filter.NewAcceptAllFilterChain(), false),
 										},
 									},
 								},

--- a/protocols/bgp/server/fsm_address_family.go
+++ b/protocols/bgp/server/fsm_address_family.go
@@ -96,7 +96,7 @@ func (f *fsmAddressFamily) init() {
 
 	f.adjRIBIn.Register(f.rib)
 
-	f.adjRIBOut = adjRIBOut.New(f.rib, peerInfo, f.exportFilterChain, !f.addPathTX.BestOnly)
+	f.adjRIBOut = adjRIBOut.New(f.rib, peerInfo, f.exportFilterChain)
 
 	f.updateSender = newUpdateSender(f)
 	f.updateSender.Start(time.Millisecond * 5)
@@ -122,6 +122,7 @@ func (f *fsmAddressFamily) getPeerInfo() *routingtable.PeerInfo {
 		RouteReflectorClient: f.fsm.peer.routeReflectorClient,
 		ClusterID:            f.fsm.peer.clusterID,
 		AddPathRX:            f.addPathRX,
+		AddPathTX:            !f.addPathTX.BestOnly,
 
 		// Only relevant for BMP use
 		RouterIP: rip,

--- a/protocols/bgp/server/fsm_address_family.go
+++ b/protocols/bgp/server/fsm_address_family.go
@@ -78,24 +78,25 @@ func (f *fsmAddressFamily) dumpRIBIn() []*route.Route {
 }
 
 type adjRIBInFactoryI interface {
-	New(exportFilterChain filter.Chain, contributingASNs *routingtable.ContributingASNs, peerParams adjRIBIn.PeerParameters) routingtable.AdjRIBIn
+	New(exportFilterChain filter.Chain, contributingASNs *routingtable.ContributingASNs, peerInfo *routingtable.PeerInfo) routingtable.AdjRIBIn
 }
 
 type adjRIBInFactory struct{}
 
-func (a adjRIBInFactory) New(exportFilterChain filter.Chain, contributingASNs *routingtable.ContributingASNs, peerParams adjRIBIn.PeerParameters) routingtable.AdjRIBIn {
-	return adjRIBIn.New(exportFilterChain, contributingASNs, peerParams)
+func (a adjRIBInFactory) New(exportFilterChain filter.Chain, contributingASNs *routingtable.ContributingASNs, peerInfo *routingtable.PeerInfo) routingtable.AdjRIBIn {
+	return adjRIBIn.New(exportFilterChain, contributingASNs, peerInfo)
 }
 
-func (f *fsmAddressFamily) init(n *routingtable.Neighbor) {
+func (f *fsmAddressFamily) init() {
 	contributingASNs := f.rib.GetContributingASNs()
+	peerInfo := f.getPeerInfo()
 
-	f.adjRIBIn = f.fsm.peer.adjRIBInFactory.New(f.importFilterChain, contributingASNs, f.peerParameters())
+	f.adjRIBIn = f.fsm.peer.adjRIBInFactory.New(f.importFilterChain, contributingASNs, peerInfo)
 	contributingASNs.Add(f.fsm.peer.localASN)
 
 	f.adjRIBIn.Register(f.rib)
 
-	f.adjRIBOut = adjRIBOut.New(f.rib, n, f.exportFilterChain, !f.addPathTX.BestOnly)
+	f.adjRIBOut = adjRIBOut.New(f.rib, peerInfo, f.exportFilterChain, !f.addPathTX.BestOnly)
 
 	f.updateSender = newUpdateSender(f)
 	f.updateSender.Start(time.Millisecond * 5)
@@ -106,25 +107,29 @@ func (f *fsmAddressFamily) init(n *routingtable.Neighbor) {
 	f.initialized = true
 }
 
-func (f *fsmAddressFamily) peerParameters() adjRIBIn.PeerParameters {
+func (f *fsmAddressFamily) getPeerInfo() *routingtable.PeerInfo {
 	rip, _ := bnet.IPFromBytes(f.fsm.bmpRouterAddress)
 
-	return adjRIBIn.PeerParameters{
-		RouterID:  f.fsm.peer.routerID,
-		ClusterID: f.fsm.peer.clusterID,
-		AddPathRX: f.addPathRX,
+	return &routingtable.PeerInfo{
+		RouterID:             f.fsm.peer.routerID,
+		PeerIP:               f.fsm.peer.addr,
+		LocalIP:              f.fsm.peer.localAddr,
+		Type:                 route.BGPPathType,
+		IBGP:                 f.fsm.peer.localASN == f.fsm.peer.peerASN,
+		LocalASN:             f.fsm.peer.localASN,
+		PeerASN:              f.fsm.peer.peerASN,
+		RouteServerClient:    f.fsm.peer.routeServerClient,
+		RouteReflectorClient: f.fsm.peer.routeReflectorClient,
+		ClusterID:            f.fsm.peer.clusterID,
+		AddPathRX:            f.addPathRX,
 
 		// Only relevant for BMP use
 		RouterIP: rip,
-		LocalIP:  f.fsm.peer.localAddr,
-		PeerIP:   f.fsm.peer.addr,
-		LocalASN: f.fsm.peer.localASN,
-		PeerASN:  f.fsm.peer.peerASN,
 	}
 }
 
 func (f *fsmAddressFamily) bmpInit() {
-	f.adjRIBIn = f.fsm.peer.adjRIBInFactory.New(filter.NewAcceptAllFilterChain(), &routingtable.ContributingASNs{}, f.peerParameters())
+	f.adjRIBIn = f.fsm.peer.adjRIBInFactory.New(filter.NewAcceptAllFilterChain(), &routingtable.ContributingASNs{}, f.getPeerInfo())
 
 	if f.rib != nil {
 		f.adjRIBIn.Register(f.rib)

--- a/protocols/bgp/server/fsm_address_family_test.go
+++ b/protocols/bgp/server/fsm_address_family_test.go
@@ -31,13 +31,9 @@ func TestFSMAFIInitDispose(t *testing.T) {
 		},
 	}
 
-	n := &routingtable.Neighbor{
-		LocalASN: 15169,
-	}
-
 	assert.Equal(t, uint64(0), f.rib.ClientCount())
 
-	f.init(n)
+	f.init()
 	assert.NotEqual(t, nil, f.adjRIBIn)
 	assert.Equal(t, true, f.rib.GetContributingASNs().IsContributingASN(15169))
 	assert.NotEqual(t, true, f.rib.GetContributingASNs().IsContributingASN(15170))

--- a/protocols/bgp/server/fsm_established.go
+++ b/protocols/bgp/server/fsm_established.go
@@ -3,14 +3,10 @@ package server
 import (
 	"bytes"
 	"fmt"
-	"net"
 	"sync/atomic"
 	"time"
 
-	bnet "github.com/bio-routing/bio-rd/net"
 	"github.com/bio-routing/bio-rd/protocols/bgp/packet"
-	"github.com/bio-routing/bio-rd/route"
-	"github.com/bio-routing/bio-rd/routingtable"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -65,32 +61,12 @@ func (s *establishedState) checkHoldtimer() (state, string) {
 }
 
 func (s *establishedState) init() error {
-	host, _, err := net.SplitHostPort(s.fsm.con.LocalAddr().String())
-	if err != nil {
-		return fmt.Errorf("unable to get local address: %w", err)
-	}
-	localAddr, err := bnet.IPFromString(host)
-	if err != nil {
-		return fmt.Errorf("unable to parse address: %w", err)
-	}
-
-	n := &routingtable.Neighbor{
-		Type:                 route.BGPPathType,
-		Address:              s.fsm.peer.addr,
-		IBGP:                 s.fsm.peer.localASN == s.fsm.peer.peerASN,
-		LocalASN:             s.fsm.peer.localASN,
-		RouteServerClient:    s.fsm.peer.routeServerClient,
-		LocalAddress:         localAddr.Dedup(),
-		RouteReflectorClient: s.fsm.peer.routeReflectorClient,
-		ClusterID:            s.fsm.peer.clusterID,
-	}
-
 	if s.fsm.ipv4Unicast != nil {
-		s.fsm.ipv4Unicast.init(n)
+		s.fsm.ipv4Unicast.init()
 	}
 
 	if s.fsm.ipv6Unicast != nil {
-		s.fsm.ipv6Unicast.init(n)
+		s.fsm.ipv6Unicast.init()
 	}
 
 	s.fsm.ribsInitialized = true

--- a/protocols/bgp/server/peer.go
+++ b/protocols/bgp/server/peer.go
@@ -5,14 +5,13 @@ import (
 	"sync"
 	"time"
 
-	"github.com/bio-routing/bio-rd/routingtable/vrf"
-
 	bnet "github.com/bio-routing/bio-rd/net"
 	"github.com/bio-routing/bio-rd/protocols/bgp/packet"
 	"github.com/bio-routing/bio-rd/route"
 	"github.com/bio-routing/bio-rd/routingtable"
 	"github.com/bio-routing/bio-rd/routingtable/filter"
 	"github.com/bio-routing/bio-rd/routingtable/locRIB"
+	"github.com/bio-routing/bio-rd/routingtable/vrf"
 )
 
 type peer struct {

--- a/routingtable/adjRIBIn/adj_rib_in.go
+++ b/routingtable/adjRIBIn/adj_rib_in.go
@@ -22,28 +22,15 @@ type AdjRIBIn struct {
 	addPathRX         bool
 }
 
-type PeerParameters struct {
-	RouterID  uint32
-	ClusterID uint32
-	AddPathRX bool
-
-	// Only relevant for BMP use
-	RouterIP net.IP
-	LocalIP  *net.IP
-	PeerIP   *net.IP
-	LocalASN uint32
-	PeerASN  uint32
-}
-
 // New creates a new Adjacency RIB In
-func New(exportFilterChain filter.Chain, contributingASNs *routingtable.ContributingASNs, peerParams PeerParameters) *AdjRIBIn {
+func New(exportFilterChain filter.Chain, contributingASNs *routingtable.ContributingASNs, peerInfo *routingtable.PeerInfo) *AdjRIBIn {
 	a := &AdjRIBIn{
 		rt:                routingtable.NewRoutingTable(),
 		exportFilterChain: exportFilterChain,
 		contributingASNs:  contributingASNs,
-		routerID:          peerParams.RouterID,
-		clusterID:         peerParams.ClusterID,
-		addPathRX:         peerParams.AddPathRX,
+		routerID:          peerInfo.RouterID,
+		clusterID:         peerInfo.ClusterID,
+		addPathRX:         peerInfo.AddPathRX,
 	}
 	a.clientManager = routingtable.NewClientManager(a)
 	return a

--- a/routingtable/adjRIBIn/adj_rib_in_test.go
+++ b/routingtable/adjRIBIn/adj_rib_in_test.go
@@ -259,12 +259,12 @@ func TestAddPath(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		peerParams := PeerParameters{
+		peerInfo := routingtable.PeerInfo{
 			RouterID:  routerID,
 			ClusterID: clusterID,
 			AddPathRX: test.addPath,
 		}
-		adjRIBIn := New(filter.NewAcceptAllFilterChain(), routingtable.NewContributingASNs(), peerParams)
+		adjRIBIn := New(filter.NewAcceptAllFilterChain(), routingtable.NewContributingASNs(), &peerInfo)
 		mc := routingtable.NewRTMockClient()
 		adjRIBIn.clientManager.RegisterWithOptions(mc, routingtable.ClientOptions{BestOnly: true})
 
@@ -489,12 +489,12 @@ func TestRemovePath(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		peerParams := PeerParameters{
+		peerInfo := routingtable.PeerInfo{
 			RouterID:  1,
 			ClusterID: 2,
 			AddPathRX: test.addPath,
 		}
-		adjRIBIn := New(filter.NewAcceptAllFilterChain(), routingtable.NewContributingASNs(), peerParams)
+		adjRIBIn := New(filter.NewAcceptAllFilterChain(), routingtable.NewContributingASNs(), &peerInfo)
 		for _, route := range test.routes {
 			adjRIBIn.AddPath(route.Prefix().Ptr(), route.Paths()[0])
 		}
@@ -522,11 +522,7 @@ func TestRemovePath(t *testing.T) {
 }
 
 func TestUnregister(t *testing.T) {
-	peerParams := PeerParameters{
-		RouterID:  0,
-		ClusterID: 0,
-		AddPathRX: false}
-	adjRIBIn := New(filter.NewAcceptAllFilterChain(), routingtable.NewContributingASNs(), peerParams)
+	adjRIBIn := New(filter.NewAcceptAllFilterChain(), routingtable.NewContributingASNs(), &routingtable.PeerInfo{})
 	mc := routingtable.NewRTMockClient()
 	adjRIBIn.Register(mc)
 

--- a/routingtable/adjRIBOut/adj_rib_out.go
+++ b/routingtable/adjRIBOut/adj_rib_out.go
@@ -20,7 +20,6 @@ type AdjRIBOut struct {
 	rib                      *locRIB.LocRIB
 	rt                       *routingtable.RoutingTable
 	peerInfo                 *routingtable.PeerInfo
-	addPathTX                bool
 	pathIDManager            *pathIDManager
 	exportFilterChain        filter.Chain
 	exportFilterChainPending filter.Chain
@@ -28,14 +27,13 @@ type AdjRIBOut struct {
 }
 
 // New creates a new Adjacency RIB Out with BGP add path
-func New(rib *locRIB.LocRIB, peerInfo *routingtable.PeerInfo, exportFilterChain filter.Chain, addPathTX bool) *AdjRIBOut {
+func New(rib *locRIB.LocRIB, peerInfo *routingtable.PeerInfo, exportFilterChain filter.Chain) *AdjRIBOut {
 	a := &AdjRIBOut{
 		rib:               rib,
 		rt:                routingtable.NewRoutingTable(),
 		peerInfo:          peerInfo,
 		pathIDManager:     newPathIDManager(),
 		exportFilterChain: exportFilterChain,
-		addPathTX:         addPathTX,
 	}
 	a.clientManager = routingtable.NewClientManager(a)
 	return a
@@ -66,7 +64,7 @@ func (a *AdjRIBOut) RouteCount() int64 {
 
 func (a *AdjRIBOut) bgpChecks(pfx *bnet.Prefix, p *route.Path) (retPath *route.Path, propagate bool) {
 	if !routingtable.ShouldPropagateUpdate(pfx, p, a.peerInfo) {
-		if a.addPathTX {
+		if a.peerInfo.AddPathTX {
 			a.removePathsForPrefix(pfx)
 		}
 		return nil, false
@@ -140,7 +138,7 @@ func (a *AdjRIBOut) AddPath(pfx *bnet.Prefix, p *route.Path) error {
 }
 
 func (a *AdjRIBOut) addPath(pfx *bnet.Prefix, p *route.Path) error {
-	if a.addPathTX {
+	if a.peerInfo.AddPathTX {
 		pathID, err := a.pathIDManager.addPath(p)
 		if err != nil {
 			return fmt.Errorf("unable to get path ID: %w", err)
@@ -187,7 +185,7 @@ func (a *AdjRIBOut) removePath(pfx *bnet.Prefix, p *route.Path) bool {
 	}
 
 	sentPath := p
-	if a.addPathTX {
+	if a.peerInfo.AddPathTX {
 		for _, sp := range r.Paths() {
 			if sp.Select(p) == 0 {
 				a.rt.RemovePath(pfx, sp)

--- a/routingtable/adjRIBOut/adj_rib_out.go
+++ b/routingtable/adjRIBOut/adj_rib_out.go
@@ -62,7 +62,7 @@ func (a *AdjRIBOut) RouteCount() int64 {
 	return a.rt.GetRouteCount()
 }
 
-func (a *AdjRIBOut) bgpChecks(pfx *bnet.Prefix, p *route.Path) (retPath *route.Path, propagate bool) {
+func (a *AdjRIBOut) checkPropagateUpdate(pfx *bnet.Prefix, p *route.Path) (retPath *route.Path, propagate bool) {
 	if !routingtable.ShouldPropagateUpdate(pfx, p, a.peerInfo) {
 		if a.peerInfo.AddPathTX {
 			a.removePathsForPrefix(pfx)
@@ -70,16 +70,21 @@ func (a *AdjRIBOut) bgpChecks(pfx *bnet.Prefix, p *route.Path) (retPath *route.P
 		return nil, false
 	}
 
+	p = p.Copy()
+
+	// iBGP neighbor
+	if a.peerInfo.IBGP {
+		return a.checkPropagateUpdateIBGP(pfx, p)
+	}
+
+	// eBGP neighbor
+	return a.checkPropagateUpdateEBGP(pfx, p)
+}
+
+func (a *AdjRIBOut) checkPropagateUpdateIBGP(pfx *bnet.Prefix, p *route.Path) (retPath *route.Path, propagate bool) {
 	// Don't export routes learned via iBGP to an iBGP neighbor which is NOT a route reflection client
 	if !p.BGPPath.BGPPathA.EBGP && a.peerInfo.IBGP && !a.peerInfo.RouteReflectorClient {
 		return nil, false
-	}
-
-	// If the neighbor is an eBGP peer and not a Route Server client modify ASPath and Next Hop
-	p = p.Copy()
-	if !a.peerInfo.IBGP && !a.peerInfo.RouteServerClient {
-		p.BGPPath.Prepend(a.peerInfo.LocalASN, 1)
-		p.BGPPath.BGPPathA.NextHop = a.peerInfo.LocalIP
 	}
 
 	// If the iBGP neighbor is a route reflection client...
@@ -97,7 +102,6 @@ func (a *AdjRIBOut) bgpChecks(pfx *bnet.Prefix, p *route.Path) (retPath *route.P
 		 * When an RR reflects a route, it MUST prepend the local CLUSTER_ID to the CLUSTER_LIST.
 		 * If the CLUSTER_LIST is empty, it MUST create a new one.
 		 */
-
 		x := 1
 		if p.BGPPath.ClusterList != nil {
 			x += len(*p.BGPPath.ClusterList)
@@ -113,13 +117,23 @@ func (a *AdjRIBOut) bgpChecks(pfx *bnet.Prefix, p *route.Path) (retPath *route.P
 	return p, true
 }
 
+func (a *AdjRIBOut) checkPropagateUpdateEBGP(pfx *bnet.Prefix, p *route.Path) (retPath *route.Path, propagate bool) {
+	// If the neighbor is an eBGP peer and not a Route Server client modify ASPath and Next Hop
+	if !a.peerInfo.RouteServerClient {
+		p.BGPPath.Prepend(a.peerInfo.LocalASN, 1)
+		p.BGPPath.BGPPathA.NextHop = a.peerInfo.LocalIP
+	}
+
+	return p, true
+}
+
 func (a *AdjRIBOut) AddPathInitialDump(pfx *bnet.Prefix, p *route.Path) error {
 	return a.AddPath(pfx, p)
 }
 
 // AddPath adds path p to prefix `pfx`
 func (a *AdjRIBOut) AddPath(pfx *bnet.Prefix, p *route.Path) error {
-	p, propagate := a.bgpChecks(pfx, p)
+	p, propagate := a.checkPropagateUpdate(pfx, p)
 	if !propagate {
 		return nil
 	}
@@ -304,7 +318,7 @@ func (a *AdjRIBOut) ReplacePath(pfx *net.Prefix, old *route.Path, new *route.Pat
 // RefreshRoute refreshes a route
 func (a *AdjRIBOut) RefreshRoute(pfx *net.Prefix, ribPaths []*route.Path) {
 	for _, p := range ribPaths {
-		p, propagate := a.bgpChecks(pfx, p)
+		p, propagate := a.checkPropagateUpdate(pfx, p)
 		if !propagate {
 			continue
 		}

--- a/routingtable/adjRIBOut/adj_rib_out.go
+++ b/routingtable/adjRIBOut/adj_rib_out.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/bio-routing/bio-rd/net"
 	bnet "github.com/bio-routing/bio-rd/net"
 	"github.com/bio-routing/bio-rd/protocols/bgp/types"
 	"github.com/bio-routing/bio-rd/route"
@@ -276,7 +275,7 @@ func (a *AdjRIBOut) Print() string {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 
-	ret := fmt.Sprintf("DUMPING ADJ-RIB-OUT:\n")
+	ret := "DUMPING ADJ-RIB-OUT:\n"
 	routes := a.rt.Dump()
 	for _, r := range routes {
 		ret += fmt.Sprintf("%s\n", r.Prefix().String())
@@ -311,12 +310,12 @@ func (a *AdjRIBOut) ReplaceFilterChain(c filter.Chain) {
 }
 
 // ReplacePath is here to fulfill an interface
-func (a *AdjRIBOut) ReplacePath(pfx *net.Prefix, old *route.Path, new *route.Path) {
+func (a *AdjRIBOut) ReplacePath(pfx *bnet.Prefix, old *route.Path, new *route.Path) {
 
 }
 
 // RefreshRoute refreshes a route
-func (a *AdjRIBOut) RefreshRoute(pfx *net.Prefix, ribPaths []*route.Path) {
+func (a *AdjRIBOut) RefreshRoute(pfx *bnet.Prefix, ribPaths []*route.Path) {
 	for _, p := range ribPaths {
 		p, propagate := a.checkPropagateUpdate(pfx, p)
 		if !propagate {
@@ -352,17 +351,17 @@ func (a *AdjRIBOut) RefreshRoute(pfx *net.Prefix, ribPaths []*route.Path) {
 }
 
 // LPM performs a longest prefix match on the routing table
-func (a *AdjRIBOut) LPM(pfx *net.Prefix) (res []*route.Route) {
+func (a *AdjRIBOut) LPM(pfx *bnet.Prefix) (res []*route.Route) {
 	return a.rt.LPM(pfx)
 }
 
 // Get gets a route
-func (a *AdjRIBOut) Get(pfx *net.Prefix) *route.Route {
+func (a *AdjRIBOut) Get(pfx *bnet.Prefix) *route.Route {
 	return a.rt.Get(pfx)
 }
 
 // GetLonger gets all more specifics
-func (a *AdjRIBOut) GetLonger(pfx *net.Prefix) (res []*route.Route) {
+func (a *AdjRIBOut) GetLonger(pfx *bnet.Prefix) (res []*route.Route) {
 	return a.rt.GetLonger(pfx)
 }
 

--- a/routingtable/adjRIBOut/adj_rib_out_test.go
+++ b/routingtable/adjRIBOut/adj_rib_out_test.go
@@ -15,16 +15,16 @@ import (
 )
 
 func TestBestPathOnlyEBGP(t *testing.T) {
-	neighborBestOnlyEBGP := &routingtable.Neighbor{
+	peerInfoBestOnlyEBGP := &routingtable.PeerInfo{
 		Type:              route.BGPPathType,
-		LocalAddress:      net.IPv4FromOctets(127, 0, 0, 1).Ptr(),
-		Address:           net.IPv4FromOctets(127, 0, 0, 2).Ptr(),
+		LocalIP:           net.IPv4FromOctets(127, 0, 0, 1).Ptr(),
+		PeerIP:            net.IPv4FromOctets(127, 0, 0, 2).Ptr(),
 		IBGP:              false,
 		LocalASN:          41981,
 		RouteServerClient: false,
 	}
 
-	adjRIBOut := New(nil, neighborBestOnlyEBGP, filter.NewAcceptAllFilterChain(), false)
+	adjRIBOut := New(nil, peerInfoBestOnlyEBGP, filter.NewAcceptAllFilterChain(), false)
 
 	tests := []struct {
 		name          string
@@ -51,7 +51,7 @@ func TestBestPathOnlyEBGP(t *testing.T) {
 					Type: route.BGPPathType,
 					BGPPath: &route.BGPPath{
 						BGPPathA: &route.BGPPathA{
-							NextHop:   neighborBestOnlyEBGP.LocalAddress,
+							NextHop:   peerInfoBestOnlyEBGP.LocalIP,
 							Origin:    0,
 							MED:       0,
 							EBGP:      false,
@@ -62,7 +62,7 @@ func TestBestPathOnlyEBGP(t *testing.T) {
 							types.ASPathSegment{
 								Type: types.ASSequence,
 								ASNs: []uint32{
-									neighborBestOnlyEBGP.LocalASN,
+									peerInfoBestOnlyEBGP.LocalASN,
 								},
 							},
 						},
@@ -81,7 +81,7 @@ func TestBestPathOnlyEBGP(t *testing.T) {
 					Type: route.BGPPathType,
 					BGPPath: &route.BGPPath{
 						BGPPathA: &route.BGPPathA{
-							NextHop:   neighborBestOnlyEBGP.LocalAddress,
+							NextHop:   peerInfoBestOnlyEBGP.LocalIP,
 							Origin:    0,
 							MED:       1,
 							EBGP:      false,
@@ -92,7 +92,7 @@ func TestBestPathOnlyEBGP(t *testing.T) {
 							types.ASPathSegment{
 								Type: types.ASSequence,
 								ASNs: []uint32{
-									neighborBestOnlyEBGP.LocalASN,
+									peerInfoBestOnlyEBGP.LocalASN,
 								},
 							},
 						},
@@ -109,7 +109,7 @@ func TestBestPathOnlyEBGP(t *testing.T) {
 					Type: route.BGPPathType,
 					BGPPath: &route.BGPPath{
 						BGPPathA: &route.BGPPathA{
-							NextHop:   neighborBestOnlyEBGP.LocalAddress,
+							NextHop:   peerInfoBestOnlyEBGP.LocalIP,
 							Origin:    0,
 							MED:       0,
 							EBGP:      false,
@@ -120,7 +120,7 @@ func TestBestPathOnlyEBGP(t *testing.T) {
 							types.ASPathSegment{
 								Type: types.ASSequence,
 								ASNs: []uint32{
-									neighborBestOnlyEBGP.LocalASN,
+									peerInfoBestOnlyEBGP.LocalASN,
 								},
 							},
 						},
@@ -139,7 +139,7 @@ func TestBestPathOnlyEBGP(t *testing.T) {
 					Type: route.BGPPathType,
 					BGPPath: &route.BGPPath{
 						BGPPathA: &route.BGPPathA{
-							NextHop:   neighborBestOnlyEBGP.LocalAddress,
+							NextHop:   peerInfoBestOnlyEBGP.LocalIP,
 							Origin:    0,
 							MED:       0,
 							EBGP:      false,
@@ -150,7 +150,7 @@ func TestBestPathOnlyEBGP(t *testing.T) {
 							types.ASPathSegment{
 								Type: types.ASSequence,
 								ASNs: []uint32{
-									neighborBestOnlyEBGP.LocalASN,
+									peerInfoBestOnlyEBGP.LocalASN,
 								},
 							},
 						},
@@ -219,7 +219,7 @@ func TestBestPathOnlyEBGP(t *testing.T) {
 					Type: route.BGPPathType,
 					BGPPath: &route.BGPPath{
 						BGPPathA: &route.BGPPathA{
-							NextHop:   neighborBestOnlyEBGP.LocalAddress,
+							NextHop:   peerInfoBestOnlyEBGP.LocalIP,
 							Origin:    0,
 							MED:       0,
 							EBGP:      false,
@@ -230,7 +230,7 @@ func TestBestPathOnlyEBGP(t *testing.T) {
 							types.ASPathSegment{
 								Type: types.ASSequence,
 								ASNs: []uint32{
-									neighborBestOnlyEBGP.LocalASN,
+									peerInfoBestOnlyEBGP.LocalASN,
 								},
 							},
 						},
@@ -249,7 +249,7 @@ func TestBestPathOnlyEBGP(t *testing.T) {
 					Type: route.BGPPathType,
 					BGPPath: &route.BGPPath{
 						BGPPathA: &route.BGPPathA{
-							NextHop:   neighborBestOnlyEBGP.LocalAddress,
+							NextHop:   peerInfoBestOnlyEBGP.LocalIP,
 							Origin:    0,
 							MED:       0,
 							EBGP:      false,
@@ -260,7 +260,7 @@ func TestBestPathOnlyEBGP(t *testing.T) {
 							types.ASPathSegment{
 								Type: types.ASSequence,
 								ASNs: []uint32{
-									neighborBestOnlyEBGP.LocalASN,
+									peerInfoBestOnlyEBGP.LocalASN,
 								},
 							},
 						},
@@ -279,7 +279,7 @@ func TestBestPathOnlyEBGP(t *testing.T) {
 					Type: route.BGPPathType,
 					BGPPath: &route.BGPPath{
 						BGPPathA: &route.BGPPathA{
-							NextHop:   neighborBestOnlyEBGP.LocalAddress,
+							NextHop:   peerInfoBestOnlyEBGP.LocalIP,
 							Origin:    0,
 							MED:       0,
 							EBGP:      false,
@@ -290,7 +290,7 @@ func TestBestPathOnlyEBGP(t *testing.T) {
 							types.ASPathSegment{
 								Type: types.ASSequence,
 								ASNs: []uint32{
-									neighborBestOnlyEBGP.LocalASN,
+									peerInfoBestOnlyEBGP.LocalASN,
 								},
 							},
 						},
@@ -320,7 +320,7 @@ func TestBestPathOnlyEBGP(t *testing.T) {
 					Type: route.BGPPathType,
 					BGPPath: &route.BGPPath{
 						BGPPathA: &route.BGPPathA{
-							NextHop:   neighborBestOnlyEBGP.LocalAddress,
+							NextHop:   peerInfoBestOnlyEBGP.LocalIP,
 							Origin:    0,
 							MED:       0,
 							EBGP:      false,
@@ -331,7 +331,7 @@ func TestBestPathOnlyEBGP(t *testing.T) {
 							types.ASPathSegment{
 								Type: types.ASSequence,
 								ASNs: []uint32{
-									neighborBestOnlyEBGP.LocalASN,
+									peerInfoBestOnlyEBGP.LocalASN,
 								},
 							},
 						},
@@ -365,16 +365,16 @@ func TestBestPathOnlyEBGP(t *testing.T) {
 }
 
 func TestBestPathOnlyIBGP(t *testing.T) {
-	neighborBestOnlyEBGP := &routingtable.Neighbor{
+	peerInfoBestOnlyEBGP := &routingtable.PeerInfo{
 		Type:              route.BGPPathType,
-		LocalAddress:      net.IPv4FromOctets(127, 0, 0, 1).Ptr(),
-		Address:           net.IPv4FromOctets(127, 0, 0, 2).Ptr(),
+		LocalIP:           net.IPv4FromOctets(127, 0, 0, 1).Ptr(),
+		PeerIP:            net.IPv4FromOctets(127, 0, 0, 2).Ptr(),
 		IBGP:              true,
 		LocalASN:          41981,
 		RouteServerClient: false,
 	}
 
-	adjRIBOut := New(nil, neighborBestOnlyEBGP, filter.NewAcceptAllFilterChain(), false)
+	adjRIBOut := New(nil, peerInfoBestOnlyEBGP, filter.NewAcceptAllFilterChain(), false)
 
 	testSteps := []struct {
 		name          string
@@ -596,10 +596,10 @@ func TestBestPathOnlyIBGP(t *testing.T) {
  */
 
 func TestBestPathOnlyRRClient(t *testing.T) {
-	neighborBestOnlyRR := &routingtable.Neighbor{
+	peerInfoBestOnlyRR := &routingtable.PeerInfo{
 		Type:                 route.BGPPathType,
-		LocalAddress:         net.IPv4FromOctets(127, 0, 0, 1).Ptr(),
-		Address:              net.IPv4FromOctets(127, 0, 0, 2).Ptr(),
+		LocalIP:              net.IPv4FromOctets(127, 0, 0, 1).Ptr(),
+		PeerIP:               net.IPv4FromOctets(127, 0, 0, 2).Ptr(),
 		IBGP:                 true,
 		LocalASN:             41981,
 		RouteServerClient:    false,
@@ -607,7 +607,7 @@ func TestBestPathOnlyRRClient(t *testing.T) {
 		ClusterID:            net.IPv4FromOctets(2, 2, 2, 2).Ptr().ToUint32(),
 	}
 
-	adjRIBOut := New(nil, neighborBestOnlyRR, filter.NewAcceptAllFilterChain(), false)
+	adjRIBOut := New(nil, peerInfoBestOnlyRR, filter.NewAcceptAllFilterChain(), false)
 
 	tests := []struct {
 		name          string
@@ -640,7 +640,7 @@ func TestBestPathOnlyRRClient(t *testing.T) {
 						},
 						ASPath: &types.ASPath{},
 						ClusterList: &types.ClusterList{
-							neighborBestOnlyRR.ClusterID,
+							peerInfoBestOnlyRR.ClusterID,
 						},
 					},
 				}),
@@ -694,7 +694,7 @@ func TestBestPathOnlyRRClient(t *testing.T) {
 						UnknownAttributes: nil,
 						PathIdentifier:    0,
 						ClusterList: &types.ClusterList{
-							neighborBestOnlyRR.ClusterID,
+							peerInfoBestOnlyRR.ClusterID,
 						},
 					},
 				}),
@@ -755,7 +755,7 @@ func TestBestPathOnlyRRClient(t *testing.T) {
 						UnknownAttributes: nil,
 						PathIdentifier:    0,
 						ClusterList: &types.ClusterList{
-							neighborBestOnlyRR.ClusterID,
+							peerInfoBestOnlyRR.ClusterID,
 						},
 					},
 				}),
@@ -788,7 +788,7 @@ func TestBestPathOnlyRRClient(t *testing.T) {
 						UnknownAttributes: nil,
 						PathIdentifier:    0,
 						ClusterList: &types.ClusterList{
-							neighborBestOnlyRR.ClusterID,
+							peerInfoBestOnlyRR.ClusterID,
 						},
 					},
 				}),
@@ -849,7 +849,7 @@ func TestBestPathOnlyRRClient(t *testing.T) {
 						},
 						PathIdentifier: 0,
 						ClusterList: &types.ClusterList{
-							neighborBestOnlyRR.ClusterID,
+							peerInfoBestOnlyRR.ClusterID,
 						},
 					},
 				}),
@@ -876,7 +876,7 @@ func TestBestPathOnlyRRClient(t *testing.T) {
 						},
 						PathIdentifier: 0,
 						ClusterList: &types.ClusterList{
-							neighborBestOnlyRR.ClusterID,
+							peerInfoBestOnlyRR.ClusterID,
 						},
 					},
 				}),
@@ -918,7 +918,7 @@ func TestBestPathOnlyRRClient(t *testing.T) {
 						UnknownAttributes: nil,
 						PathIdentifier:    0,
 						ClusterList: &types.ClusterList{
-							neighborBestOnlyRR.ClusterID,
+							peerInfoBestOnlyRR.ClusterID,
 							23,
 						},
 					},
@@ -952,16 +952,16 @@ func TestBestPathOnlyRRClient(t *testing.T) {
  */
 
 func TestAddPathIBGP(t *testing.T) {
-	neighborBestOnlyEBGP := &routingtable.Neighbor{
+	peerInfoBestOnlyEBGP := &routingtable.PeerInfo{
 		Type:              route.BGPPathType,
-		LocalAddress:      net.IPv4FromOctets(127, 0, 0, 1).Ptr(),
-		Address:           net.IPv4FromOctets(127, 0, 0, 2).Ptr(),
+		LocalIP:           net.IPv4FromOctets(127, 0, 0, 1).Ptr(),
+		PeerIP:            net.IPv4FromOctets(127, 0, 0, 2).Ptr(),
 		IBGP:              true,
 		LocalASN:          41981,
 		RouteServerClient: false,
 	}
 
-	adjRIBOut := New(nil, neighborBestOnlyEBGP, filter.NewAcceptAllFilterChain(), true)
+	adjRIBOut := New(nil, peerInfoBestOnlyEBGP, filter.NewAcceptAllFilterChain(), true)
 
 	tests := []struct {
 		name          string

--- a/routingtable/adjRIBOut/adj_rib_out_test.go
+++ b/routingtable/adjRIBOut/adj_rib_out_test.go
@@ -22,9 +22,10 @@ func TestBestPathOnlyEBGP(t *testing.T) {
 		IBGP:              false,
 		LocalASN:          41981,
 		RouteServerClient: false,
+		AddPathTX:         false,
 	}
 
-	adjRIBOut := New(nil, peerInfoBestOnlyEBGP, filter.NewAcceptAllFilterChain(), false)
+	adjRIBOut := New(nil, peerInfoBestOnlyEBGP, filter.NewAcceptAllFilterChain())
 
 	tests := []struct {
 		name          string
@@ -372,9 +373,10 @@ func TestBestPathOnlyIBGP(t *testing.T) {
 		IBGP:              true,
 		LocalASN:          41981,
 		RouteServerClient: false,
+		AddPathTX:         false,
 	}
 
-	adjRIBOut := New(nil, peerInfoBestOnlyEBGP, filter.NewAcceptAllFilterChain(), false)
+	adjRIBOut := New(nil, peerInfoBestOnlyEBGP, filter.NewAcceptAllFilterChain())
 
 	testSteps := []struct {
 		name          string
@@ -605,9 +607,10 @@ func TestBestPathOnlyRRClient(t *testing.T) {
 		RouteServerClient:    false,
 		RouteReflectorClient: true,
 		ClusterID:            net.IPv4FromOctets(2, 2, 2, 2).Ptr().ToUint32(),
+		AddPathTX:            false,
 	}
 
-	adjRIBOut := New(nil, peerInfoBestOnlyRR, filter.NewAcceptAllFilterChain(), false)
+	adjRIBOut := New(nil, peerInfoBestOnlyRR, filter.NewAcceptAllFilterChain())
 
 	tests := []struct {
 		name          string
@@ -959,9 +962,10 @@ func TestAddPathIBGP(t *testing.T) {
 		IBGP:              true,
 		LocalASN:          41981,
 		RouteServerClient: false,
+		AddPathTX:         true,
 	}
 
-	adjRIBOut := New(nil, peerInfoBestOnlyEBGP, filter.NewAcceptAllFilterChain(), true)
+	adjRIBOut := New(nil, peerInfoBestOnlyEBGP, filter.NewAcceptAllFilterChain())
 
 	tests := []struct {
 		name          string

--- a/routingtable/adjRIBOut/path_id_manager.go
+++ b/routingtable/adjRIBOut/path_id_manager.go
@@ -33,7 +33,7 @@ func (fm *pathIDManager) addPath(p *route.Path) (uint32, error) {
 	}
 
 	if fm.used == maxUint32 {
-		return 0, fmt.Errorf("Out of path IDs")
+		return 0, fmt.Errorf("out of path IDs")
 	}
 
 	fm.last++

--- a/routingtable/client_manager_test.go
+++ b/routingtable/client_manager_test.go
@@ -37,33 +37,21 @@ func (m MockClient) UpdateNewClient(RouteTableClient) error {
 	return nil
 }
 
-func (m MockClient) Register(RouteTableClient) {
-	return
-}
+func (m MockClient) Register(RouteTableClient) {}
 
-func (m MockClient) Unregister(RouteTableClient) {
-	return
-}
+func (m MockClient) Unregister(RouteTableClient) {}
 
 func (m MockClient) RouteCount() int64 {
 	return 0
 }
 
-func (m MockClient) ReplaceFilterChain(c filter.Chain) {
+func (m MockClient) ReplaceFilterChain(c filter.Chain) {}
 
-}
+func (m MockClient) ReplacePath(*net.Prefix, *route.Path, *route.Path) {}
 
-func (m MockClient) ReplacePath(*net.Prefix, *route.Path, *route.Path) {
+func (m MockClient) RefreshRoute(*net.Prefix, []*route.Path) {}
 
-}
-
-func (m MockClient) RefreshRoute(*net.Prefix, []*route.Path) {
-
-}
-
-func (m MockClient) Dispose() {
-
-}
+func (m MockClient) Dispose() {}
 
 func TestClients(t *testing.T) {
 	tests := []struct {

--- a/routingtable/mock_client.go
+++ b/routingtable/mock_client.go
@@ -46,20 +46,14 @@ func (m *RTMockClient) AddPathInitialDump(pfx *net.Prefix, p *route.Path) error 
 }
 
 func (m *RTMockClient) UpdateNewClient(client RouteTableClient) error {
-	return fmt.Errorf("Not implemented")
+	return fmt.Errorf("not implemented")
 }
 
-func (m *RTMockClient) Register(RouteTableClient) {
-	return
-}
+func (m *RTMockClient) Register(RouteTableClient) {}
 
-func (m *RTMockClient) RegisterWithOptions(RouteTableClient, ClientOptions) {
-	return
-}
+func (m *RTMockClient) RegisterWithOptions(RouteTableClient, ClientOptions) {}
 
-func (m *RTMockClient) Unregister(RouteTableClient) {
-	return
-}
+func (m *RTMockClient) Unregister(RouteTableClient) {}
 
 // RemovePath removes the path for prefix `pfx`
 func (m *RTMockClient) RemovePath(pfx *net.Prefix, p *route.Path) bool {

--- a/routingtable/peer_info.go
+++ b/routingtable/peer_info.go
@@ -2,13 +2,16 @@ package routingtable
 
 import bnet "github.com/bio-routing/bio-rd/net"
 
-// Neighbor represents the attributes identifying a neighbor relationship
-type Neighbor struct {
-	// Address is the IPv4 address of the neighbor as integer representation
-	Address *bnet.IP
+// PeerInfo represents the attributes identifying a neighbor relationship
+type PeerInfo struct {
+	// RouterID is the ID of the local router
+	RouterID uint32
 
-	// Local address is the local address of the BGP TCP connection
-	LocalAddress *bnet.IP
+	// PeerIP is the IP address of the neighbor
+	PeerIP *bnet.IP
+
+	// LocalIP is the local address of the BGP TCP connection
+	LocalIP *bnet.IP
 
 	// Type is the type / protocol used for routing inforation communitation
 	Type uint8
@@ -19,6 +22,9 @@ type Neighbor struct {
 	// Local ASN of session
 	LocalASN uint32
 
+	// Peer ASN for this neighbor
+	PeerASN uint32
+
 	// RouteServerClient indicates if the peer is a route server client
 	RouteServerClient bool
 
@@ -27,4 +33,10 @@ type Neighbor struct {
 
 	// ClusterID is our route reflectors clusterID
 	ClusterID uint32
+
+	// AddPathRX indicates if AddPath receive is active
+	AddPathRX bool
+
+	// RouterIP indicates the IP address of the remote BMP peer (only for BMP)
+	RouterIP bnet.IP
 }

--- a/routingtable/peer_info.go
+++ b/routingtable/peer_info.go
@@ -37,6 +37,9 @@ type PeerInfo struct {
 	// AddPathRX indicates if AddPath receive is active
 	AddPathRX bool
 
+	// AddPathRX indicates if AddPath receive is active
+	AddPathTX bool
+
 	// RouterIP indicates the IP address of the remote BMP peer (only for BMP)
 	RouterIP bnet.IP
 }

--- a/routingtable/trie.go
+++ b/routingtable/trie.go
@@ -121,7 +121,7 @@ func (n *node) addPath(pfx *net.Prefix, p *route.Path) (*node, bool) {
 		// Store previous dummy-ness to check if this node became new
 		dummy := n.dummy
 		n.dummy = false
-		return n, dummy == true
+		return n, dummy
 	}
 
 	// is pfx NOT a subnet of this node?

--- a/routingtable/update_helper.go
+++ b/routingtable/update_helper.go
@@ -7,24 +7,24 @@ import (
 )
 
 // ShouldPropagateUpdate performs some default checks and returns if an route update should be propagated to a neighbor
-func ShouldPropagateUpdate(pfx *net.Prefix, p *route.Path, n *Neighbor) bool {
-	return !isOwnPath(p, n) && !isDisallowedByCommunity(p, n)
+func ShouldPropagateUpdate(pfx *net.Prefix, p *route.Path, pi *PeerInfo) bool {
+	return !isOwnPath(p, pi) && !isDisallowedByCommunity(p, pi)
 }
 
-func isOwnPath(p *route.Path, n *Neighbor) bool {
-	if p.Type != n.Type {
+func isOwnPath(p *route.Path, pi *PeerInfo) bool {
+	if p.Type != pi.Type {
 		return false
 	}
 
 	switch p.Type {
 	case route.BGPPathType:
-		return p.BGPPath.BGPPathA.Source.Compare(n.Address) == 0
+		return p.BGPPath.BGPPathA.Source.Compare(pi.PeerIP) == 0
 	}
 
 	return false
 }
 
-func isDisallowedByCommunity(p *route.Path, n *Neighbor) bool {
+func isDisallowedByCommunity(p *route.Path, pi *PeerInfo) bool {
 	if p.BGPPath == nil || (p.BGPPath.Communities != nil && len(*p.BGPPath.Communities) == 0) {
 		return false
 	}
@@ -34,7 +34,7 @@ func isDisallowedByCommunity(p *route.Path, n *Neighbor) bool {
 	}
 
 	for _, com := range *p.BGPPath.Communities {
-		if (com == types.WellKnownCommunityNoExport && !n.IBGP) || com == types.WellKnownCommunityNoAdvertise {
+		if (com == types.WellKnownCommunityNoExport && !pi.IBGP) || com == types.WellKnownCommunityNoAdvertise {
 			return true
 		}
 	}

--- a/routingtable/update_helper_test.go
+++ b/routingtable/update_helper_test.go
@@ -14,7 +14,7 @@ func TestShouldPropagateUpdate(t *testing.T) {
 	tests := []struct {
 		name        string
 		communities string
-		neighbor    Neighbor
+		peerInfo    PeerInfo
 		expected    bool
 	}{
 		{
@@ -24,9 +24,9 @@ func TestShouldPropagateUpdate(t *testing.T) {
 		{
 			name:        "path was received from this peer before",
 			communities: "(1,2)",
-			neighbor: Neighbor{
-				Type:    route.BGPPathType,
-				Address: bnet.IPv4FromOctets(192, 168, 1, 1).Ptr(),
+			peerInfo: PeerInfo{
+				Type:   route.BGPPathType,
+				PeerIP: bnet.IPv4FromOctets(192, 168, 1, 1).Ptr(),
 			},
 			expected: false,
 		},
@@ -38,7 +38,7 @@ func TestShouldPropagateUpdate(t *testing.T) {
 		{
 			name:        "path with no-export community (iBGP)",
 			communities: "(1,2) (65535,65281)",
-			neighbor: Neighbor{
+			peerInfo: PeerInfo{
 				IBGP: true,
 			},
 			expected: true,
@@ -51,7 +51,7 @@ func TestShouldPropagateUpdate(t *testing.T) {
 		{
 			name:        "path with no-advertise community (iBGP)",
 			communities: "(1,2) (65535,65282)",
-			neighbor: Neighbor{
+			peerInfo: PeerInfo{
 				IBGP: true,
 			},
 			expected: false,
@@ -84,7 +84,7 @@ func TestShouldPropagateUpdate(t *testing.T) {
 				},
 			}
 
-			res := ShouldPropagateUpdate(pfx, pa, &test.neighbor)
+			res := ShouldPropagateUpdate(pfx, pa, &test.peerInfo)
 			assert.Equal(t, test.expected, res)
 		})
 	}


### PR DESCRIPTION
 * Deprecate Neighbor and PeerParams in favor of PeerInfo
 * Merge AddPathTX parameter of AdjRIBOut into PeerInfo
 * Split export checks for iBGP and eBGP paths
 * Resolve some nits from go-staticcheck
 * Remove internal duplication of peer attrs within AdjRIBIn

I think the structure makes more sense now and is more scalable, but I'm quite unhappy with the `PeerInfo` name. It feels like neither `Neighbor`, not `PeerParameters` or `PeerInfo` are a good name, as what we are storing and passing around are BGP related information for the `routingtable`, most of them already present within the `peer` / `PeerConfig` struct, but some derived from running state or PeerConfig/AFI. `BGPAttrs` would be a bad name IMHO given BGP Attributes are a total different thing, so `BGPInfo` or `BGPSettings` come to mind.