### PR TITLE
Unify Neighbor and PeerParams in SessionAttrs and remove redundant variables

### DIFF
--- a/protocols/bgp/server/bgp_api_test.go
+++ b/protocols/bgp/server/bgp_api_test.go
@@ -28,6 +28,7 @@ func TestDumpRIBInOut(t *testing.T) {
 		RouterID:  0,
 		ClusterID: 0,
 		AddPathRX: true,
+		AddPathTX: true,
 	}
 
 	tests := []struct {
@@ -67,7 +68,7 @@ func TestDumpRIBInOut(t *testing.T) {
 									0: {
 										ipv4Unicast: &fsmAddressFamily{
 											adjRIBIn:  adjRIBIn.New(filter.NewAcceptAllFilterChain(), nil, sessionAttrs),
-											adjRIBOut: adjRIBOut.New(nil, routingtable.SessionAttrs{Type: route.BGPPathType}, filter.NewAcceptAllFilterChain(), true),
+											adjRIBOut: adjRIBOut.New(nil, routingtable.SessionAttrs{Type: route.BGPPathType}, filter.NewAcceptAllFilterChain()),
 										},
 									},
 								},
@@ -97,7 +98,7 @@ func TestDumpRIBInOut(t *testing.T) {
 									0: {
 										ipv4Unicast: &fsmAddressFamily{
 											adjRIBIn:  adjRIBIn.New(filter.NewAcceptAllFilterChain(), nil, sessionAttrs),
-											adjRIBOut: adjRIBOut.New(nil, routingtable.SessionAttrs{Type: route.BGPPathType, RouteServerClient: true, PeerIP: bnet.IPv4(0).Ptr()}, filter.NewAcceptAllFilterChain(), false),
+											adjRIBOut: adjRIBOut.New(nil, routingtable.SessionAttrs{Type: route.BGPPathType, RouteServerClient: true, PeerIP: bnet.IPv4(0).Ptr()}, filter.NewAcceptAllFilterChain()),
 										},
 									},
 								},
@@ -146,7 +147,7 @@ func TestDumpRIBInOut(t *testing.T) {
 			wantFail: false,
 		},
 		{
-			name: "Test #3: One complex routes given",
+			name: "Test #3: One complex route given",
 			apisrv: &BGPAPIServer{
 				srv: &bgpServer{
 					peers: &peerManager{
@@ -157,7 +158,7 @@ func TestDumpRIBInOut(t *testing.T) {
 									0: {
 										ipv4Unicast: &fsmAddressFamily{
 											adjRIBIn:  adjRIBIn.New(filter.NewAcceptAllFilterChain(), routingtable.NewContributingASNs(), sessionAttrs),
-											adjRIBOut: adjRIBOut.New(nil, routingtable.SessionAttrs{Type: route.BGPPathType, RouteServerClient: true, PeerIP: bnet.IPv4(123).Ptr()}, filter.NewAcceptAllFilterChain(), false),
+											adjRIBOut: adjRIBOut.New(nil, routingtable.SessionAttrs{Type: route.BGPPathType, RouteServerClient: true, PeerIP: bnet.IPv4(123).Ptr()}, filter.NewAcceptAllFilterChain()),
 										},
 									},
 								},

--- a/protocols/bgp/server/bgp_api_test.go
+++ b/protocols/bgp/server/bgp_api_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestDumpRIBInOut(t *testing.T) {
-	peerParams := adjRIBIn.PeerParameters{
+	sessionAttrs := routingtable.SessionAttrs{
 		RouterID:  0,
 		ClusterID: 0,
 		AddPathRX: true,
@@ -66,8 +66,8 @@ func TestDumpRIBInOut(t *testing.T) {
 								fsms: []*FSM{
 									0: {
 										ipv4Unicast: &fsmAddressFamily{
-											adjRIBIn:  adjRIBIn.New(filter.NewAcceptAllFilterChain(), nil, peerParams),
-											adjRIBOut: adjRIBOut.New(nil, &routingtable.Neighbor{Type: route.BGPPathType}, filter.NewAcceptAllFilterChain(), true),
+											adjRIBIn:  adjRIBIn.New(filter.NewAcceptAllFilterChain(), nil, sessionAttrs),
+											adjRIBOut: adjRIBOut.New(nil, routingtable.SessionAttrs{Type: route.BGPPathType}, filter.NewAcceptAllFilterChain(), true),
 										},
 									},
 								},
@@ -96,8 +96,8 @@ func TestDumpRIBInOut(t *testing.T) {
 								fsms: []*FSM{
 									0: {
 										ipv4Unicast: &fsmAddressFamily{
-											adjRIBIn:  adjRIBIn.New(filter.NewAcceptAllFilterChain(), nil, peerParams),
-											adjRIBOut: adjRIBOut.New(nil, &routingtable.Neighbor{Type: route.BGPPathType, RouteServerClient: true, Address: bnet.IPv4(0).Ptr()}, filter.NewAcceptAllFilterChain(), false),
+											adjRIBIn:  adjRIBIn.New(filter.NewAcceptAllFilterChain(), nil, sessionAttrs),
+											adjRIBOut: adjRIBOut.New(nil, routingtable.SessionAttrs{Type: route.BGPPathType, RouteServerClient: true, PeerIP: bnet.IPv4(0).Ptr()}, filter.NewAcceptAllFilterChain(), false),
 										},
 									},
 								},
@@ -156,8 +156,8 @@ func TestDumpRIBInOut(t *testing.T) {
 								fsms: []*FSM{
 									0: {
 										ipv4Unicast: &fsmAddressFamily{
-											adjRIBIn:  adjRIBIn.New(filter.NewAcceptAllFilterChain(), routingtable.NewContributingASNs(), peerParams),
-											adjRIBOut: adjRIBOut.New(nil, &routingtable.Neighbor{Type: route.BGPPathType, RouteServerClient: true, Address: bnet.IPv4(123).Ptr()}, filter.NewAcceptAllFilterChain(), false),
+											adjRIBIn:  adjRIBIn.New(filter.NewAcceptAllFilterChain(), routingtable.NewContributingASNs(), sessionAttrs),
+											adjRIBOut: adjRIBOut.New(nil, routingtable.SessionAttrs{Type: route.BGPPathType, RouteServerClient: true, PeerIP: bnet.IPv4(123).Ptr()}, filter.NewAcceptAllFilterChain(), false),
 										},
 									},
 								},

--- a/protocols/bgp/server/fsm_address_family.go
+++ b/protocols/bgp/server/fsm_address_family.go
@@ -96,7 +96,7 @@ func (f *fsmAddressFamily) init() {
 
 	f.adjRIBIn.Register(f.rib)
 
-	f.adjRIBOut = adjRIBOut.New(f.rib, peerAttrs, f.exportFilterChain, !f.addPathTX.BestOnly)
+	f.adjRIBOut = adjRIBOut.New(f.rib, peerAttrs, f.exportFilterChain)
 
 	f.updateSender = newUpdateSender(f)
 	f.updateSender.Start(time.Millisecond * 5)
@@ -122,6 +122,7 @@ func (f *fsmAddressFamily) getSessionAttrs() routingtable.SessionAttrs {
 		RouteReflectorClient: f.fsm.peer.routeReflectorClient,
 		ClusterID:            f.fsm.peer.clusterID,
 		AddPathRX:            f.addPathRX,
+		AddPathTX:            !f.addPathTX.BestOnly,
 
 		// Only relevant for BMP use
 		RouterIP: rip,

--- a/protocols/bgp/server/fsm_address_family_test.go
+++ b/protocols/bgp/server/fsm_address_family_test.go
@@ -31,13 +31,9 @@ func TestFSMAFIInitDispose(t *testing.T) {
 		},
 	}
 
-	n := &routingtable.Neighbor{
-		LocalASN: 15169,
-	}
-
 	assert.Equal(t, uint64(0), f.rib.ClientCount())
 
-	f.init(n)
+	f.init()
 	assert.NotEqual(t, nil, f.adjRIBIn)
 	assert.Equal(t, true, f.rib.GetContributingASNs().IsContributingASN(15169))
 	assert.NotEqual(t, true, f.rib.GetContributingASNs().IsContributingASN(15170))

--- a/protocols/bgp/server/fsm_established.go
+++ b/protocols/bgp/server/fsm_established.go
@@ -3,14 +3,10 @@ package server
 import (
 	"bytes"
 	"fmt"
-	"net"
 	"sync/atomic"
 	"time"
 
-	bnet "github.com/bio-routing/bio-rd/net"
 	"github.com/bio-routing/bio-rd/protocols/bgp/packet"
-	"github.com/bio-routing/bio-rd/route"
-	"github.com/bio-routing/bio-rd/routingtable"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -65,32 +61,12 @@ func (s *establishedState) checkHoldtimer() (state, string) {
 }
 
 func (s *establishedState) init() error {
-	host, _, err := net.SplitHostPort(s.fsm.con.LocalAddr().String())
-	if err != nil {
-		return fmt.Errorf("unable to get local address: %w", err)
-	}
-	localAddr, err := bnet.IPFromString(host)
-	if err != nil {
-		return fmt.Errorf("unable to parse address: %w", err)
-	}
-
-	n := &routingtable.Neighbor{
-		Type:                 route.BGPPathType,
-		Address:              s.fsm.peer.addr,
-		IBGP:                 s.fsm.peer.localASN == s.fsm.peer.peerASN,
-		LocalASN:             s.fsm.peer.localASN,
-		RouteServerClient:    s.fsm.peer.routeServerClient,
-		LocalAddress:         localAddr.Dedup(),
-		RouteReflectorClient: s.fsm.peer.routeReflectorClient,
-		ClusterID:            s.fsm.peer.clusterID,
-	}
-
 	if s.fsm.ipv4Unicast != nil {
-		s.fsm.ipv4Unicast.init(n)
+		s.fsm.ipv4Unicast.init()
 	}
 
 	if s.fsm.ipv6Unicast != nil {
-		s.fsm.ipv6Unicast.init(n)
+		s.fsm.ipv6Unicast.init()
 	}
 
 	s.fsm.ribsInitialized = true

--- a/protocols/bgp/server/peer.go
+++ b/protocols/bgp/server/peer.go
@@ -5,14 +5,13 @@ import (
 	"sync"
 	"time"
 
-	"github.com/bio-routing/bio-rd/routingtable/vrf"
-
 	bnet "github.com/bio-routing/bio-rd/net"
 	"github.com/bio-routing/bio-rd/protocols/bgp/packet"
 	"github.com/bio-routing/bio-rd/route"
 	"github.com/bio-routing/bio-rd/routingtable"
 	"github.com/bio-routing/bio-rd/routingtable/filter"
 	"github.com/bio-routing/bio-rd/routingtable/locRIB"
+	"github.com/bio-routing/bio-rd/routingtable/vrf"
 )
 
 type peer struct {

--- a/routingtable/adjRIBIn/adj_rib_in.go
+++ b/routingtable/adjRIBIn/adj_rib_in.go
@@ -17,33 +17,16 @@ type AdjRIBIn struct {
 	mu                sync.RWMutex
 	exportFilterChain filter.Chain
 	contributingASNs  *routingtable.ContributingASNs
-	routerID          uint32
-	clusterID         uint32
-	addPathRX         bool
-}
-
-type PeerParameters struct {
-	RouterID  uint32
-	ClusterID uint32
-	AddPathRX bool
-
-	// Only relevant for BMP use
-	RouterIP net.IP
-	LocalIP  *net.IP
-	PeerIP   *net.IP
-	LocalASN uint32
-	PeerASN  uint32
+	sessionAttrs      routingtable.SessionAttrs
 }
 
 // New creates a new Adjacency RIB In
-func New(exportFilterChain filter.Chain, contributingASNs *routingtable.ContributingASNs, peerParams PeerParameters) *AdjRIBIn {
+func New(exportFilterChain filter.Chain, contributingASNs *routingtable.ContributingASNs, sessionAttrs routingtable.SessionAttrs) *AdjRIBIn {
 	a := &AdjRIBIn{
 		rt:                routingtable.NewRoutingTable(),
 		exportFilterChain: exportFilterChain,
 		contributingASNs:  contributingASNs,
-		routerID:          peerParams.RouterID,
-		clusterID:         peerParams.ClusterID,
-		addPathRX:         peerParams.AddPathRX,
+		sessionAttrs:      sessionAttrs,
 	}
 	a.clientManager = routingtable.NewClientManager(a)
 	return a
@@ -162,7 +145,7 @@ func (a *AdjRIBIn) AddPath(pfx *net.Prefix, p *route.Path) error {
 // addPath replaces the path for prefix `pfx`. If the prefix doesn't exist it is added.
 func (a *AdjRIBIn) addPath(pfx *net.Prefix, p *route.Path) error {
 	var oldPaths []*route.Path
-	if a.addPathRX {
+	if a.sessionAttrs.AddPathRX {
 		oldPaths = make([]*route.Path, 0)
 		r := a.rt.Get(pfx)
 		if r != nil {
@@ -216,7 +199,7 @@ func (a *AdjRIBIn) removePath(pfx *net.Prefix, p *route.Path) bool {
 	removed := make([]*route.Path, 0)
 	oldPaths := r.Paths()
 	for _, path := range oldPaths {
-		if a.addPathRX {
+		if a.sessionAttrs.AddPathRX {
 			if p != nil && path.BGPPath.PathIdentifier != p.BGPPath.PathIdentifier {
 				continue
 			}
@@ -302,14 +285,14 @@ func (a *AdjRIBIn) validatePath(p *route.Path) uint8 {
 	}
 
 	// RFC4456 Sect. 8: Ignore route with our RouterID as OriginatorID
-	if p.BGPPath.BGPPathA.OriginatorID == a.routerID {
+	if p.BGPPath.BGPPathA.OriginatorID == a.sessionAttrs.RouterID {
 		return route.HiddenReasonOurOriginatorID
 	}
 
 	// RFC4456 Sect. 8: Ignore routes which contain our ClusterID in their ClusterList
 	if p.BGPPath.ClusterList != nil && len(*p.BGPPath.ClusterList) > 0 {
 		for _, cid := range *p.BGPPath.ClusterList {
-			if cid == a.clusterID {
+			if cid == a.sessionAttrs.ClusterID {
 				return route.HiddenReasonClusterLoop
 			}
 		}

--- a/routingtable/adjRIBIn/adj_rib_in_test.go
+++ b/routingtable/adjRIBIn/adj_rib_in_test.go
@@ -259,12 +259,12 @@ func TestAddPath(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		peerParams := PeerParameters{
+		sessionAttrs := routingtable.SessionAttrs{
 			RouterID:  routerID,
 			ClusterID: clusterID,
 			AddPathRX: test.addPath,
 		}
-		adjRIBIn := New(filter.NewAcceptAllFilterChain(), routingtable.NewContributingASNs(), peerParams)
+		adjRIBIn := New(filter.NewAcceptAllFilterChain(), routingtable.NewContributingASNs(), sessionAttrs)
 		mc := routingtable.NewRTMockClient()
 		adjRIBIn.clientManager.RegisterWithOptions(mc, routingtable.ClientOptions{BestOnly: true})
 
@@ -489,12 +489,12 @@ func TestRemovePath(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		peerParams := PeerParameters{
+		sessionAttrs := routingtable.SessionAttrs{
 			RouterID:  1,
 			ClusterID: 2,
 			AddPathRX: test.addPath,
 		}
-		adjRIBIn := New(filter.NewAcceptAllFilterChain(), routingtable.NewContributingASNs(), peerParams)
+		adjRIBIn := New(filter.NewAcceptAllFilterChain(), routingtable.NewContributingASNs(), sessionAttrs)
 		for _, route := range test.routes {
 			adjRIBIn.AddPath(route.Prefix().Ptr(), route.Paths()[0])
 		}
@@ -522,11 +522,7 @@ func TestRemovePath(t *testing.T) {
 }
 
 func TestUnregister(t *testing.T) {
-	peerParams := PeerParameters{
-		RouterID:  0,
-		ClusterID: 0,
-		AddPathRX: false}
-	adjRIBIn := New(filter.NewAcceptAllFilterChain(), routingtable.NewContributingASNs(), peerParams)
+	adjRIBIn := New(filter.NewAcceptAllFilterChain(), routingtable.NewContributingASNs(), routingtable.SessionAttrs{})
 	mc := routingtable.NewRTMockClient()
 	adjRIBIn.Register(mc)
 

--- a/routingtable/adjRIBOut/adj_rib_out.go
+++ b/routingtable/adjRIBOut/adj_rib_out.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/bio-routing/bio-rd/net"
 	bnet "github.com/bio-routing/bio-rd/net"
 	"github.com/bio-routing/bio-rd/protocols/bgp/types"
 	"github.com/bio-routing/bio-rd/route"
@@ -274,7 +273,7 @@ func (a *AdjRIBOut) Print() string {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 
-	ret := fmt.Sprintf("DUMPING ADJ-RIB-OUT:\n")
+	ret := "DUMPING ADJ-RIB-OUT:\n"
 	routes := a.rt.Dump()
 	for _, r := range routes {
 		ret += fmt.Sprintf("%s\n", r.Prefix().String())
@@ -309,12 +308,12 @@ func (a *AdjRIBOut) ReplaceFilterChain(c filter.Chain) {
 }
 
 // ReplacePath is here to fulfill an interface
-func (a *AdjRIBOut) ReplacePath(pfx *net.Prefix, old *route.Path, new *route.Path) {
+func (a *AdjRIBOut) ReplacePath(pfx *bnet.Prefix, old *route.Path, new *route.Path) {
 
 }
 
 // RefreshRoute refreshes a route
-func (a *AdjRIBOut) RefreshRoute(pfx *net.Prefix, ribPaths []*route.Path) {
+func (a *AdjRIBOut) RefreshRoute(pfx *bnet.Prefix, ribPaths []*route.Path) {
 	for _, p := range ribPaths {
 		p, propagate := a.checkPropagateUpdate(pfx, p)
 		if !propagate {
@@ -350,17 +349,17 @@ func (a *AdjRIBOut) RefreshRoute(pfx *net.Prefix, ribPaths []*route.Path) {
 }
 
 // LPM performs a longest prefix match on the routing table
-func (a *AdjRIBOut) LPM(pfx *net.Prefix) (res []*route.Route) {
+func (a *AdjRIBOut) LPM(pfx *bnet.Prefix) (res []*route.Route) {
 	return a.rt.LPM(pfx)
 }
 
 // Get gets a route
-func (a *AdjRIBOut) Get(pfx *net.Prefix) *route.Route {
+func (a *AdjRIBOut) Get(pfx *bnet.Prefix) *route.Route {
 	return a.rt.Get(pfx)
 }
 
 // GetLonger gets all more specifics
-func (a *AdjRIBOut) GetLonger(pfx *net.Prefix) (res []*route.Route) {
+func (a *AdjRIBOut) GetLonger(pfx *bnet.Prefix) (res []*route.Route) {
 	return a.rt.GetLonger(pfx)
 }
 

--- a/routingtable/adjRIBOut/adj_rib_out.go
+++ b/routingtable/adjRIBOut/adj_rib_out.go
@@ -19,7 +19,7 @@ type AdjRIBOut struct {
 	clientManager            *routingtable.ClientManager
 	rib                      *locRIB.LocRIB
 	rt                       *routingtable.RoutingTable
-	neighbor                 *routingtable.Neighbor
+	sessionAttrs             routingtable.SessionAttrs
 	addPathTX                bool
 	pathIDManager            *pathIDManager
 	exportFilterChain        filter.Chain
@@ -28,11 +28,11 @@ type AdjRIBOut struct {
 }
 
 // New creates a new Adjacency RIB Out with BGP add path
-func New(rib *locRIB.LocRIB, neighbor *routingtable.Neighbor, exportFilterChain filter.Chain, addPathTX bool) *AdjRIBOut {
+func New(rib *locRIB.LocRIB, sessionAttrs routingtable.SessionAttrs, exportFilterChain filter.Chain, addPathTX bool) *AdjRIBOut {
 	a := &AdjRIBOut{
 		rib:               rib,
 		rt:                routingtable.NewRoutingTable(),
-		neighbor:          neighbor,
+		sessionAttrs:      sessionAttrs,
 		pathIDManager:     newPathIDManager(),
 		exportFilterChain: exportFilterChain,
 		addPathTX:         addPathTX,
@@ -65,7 +65,7 @@ func (a *AdjRIBOut) RouteCount() int64 {
 }
 
 func (a *AdjRIBOut) bgpChecks(pfx *bnet.Prefix, p *route.Path) (retPath *route.Path, propagate bool) {
-	if !routingtable.ShouldPropagateUpdate(pfx, p, a.neighbor) {
+	if !routingtable.ShouldPropagateUpdate(pfx, p, &a.sessionAttrs) {
 		if a.addPathTX {
 			a.removePathsForPrefix(pfx)
 		}
@@ -73,19 +73,19 @@ func (a *AdjRIBOut) bgpChecks(pfx *bnet.Prefix, p *route.Path) (retPath *route.P
 	}
 
 	// Don't export routes learned via iBGP to an iBGP neighbor which is NOT a route reflection client
-	if !p.BGPPath.BGPPathA.EBGP && a.neighbor.IBGP && !a.neighbor.RouteReflectorClient {
+	if !p.BGPPath.BGPPathA.EBGP && a.sessionAttrs.IBGP && !a.sessionAttrs.RouteReflectorClient {
 		return nil, false
 	}
 
 	// If the neighbor is an eBGP peer and not a Route Server client modify ASPath and Next Hop
 	p = p.Copy()
-	if !a.neighbor.IBGP && !a.neighbor.RouteServerClient {
-		p.BGPPath.Prepend(a.neighbor.LocalASN, 1)
-		p.BGPPath.BGPPathA.NextHop = a.neighbor.LocalAddress
+	if !a.sessionAttrs.IBGP && !a.sessionAttrs.RouteServerClient {
+		p.BGPPath.Prepend(a.sessionAttrs.LocalASN, 1)
+		p.BGPPath.BGPPathA.NextHop = a.sessionAttrs.LocalIP
 	}
 
 	// If the iBGP neighbor is a route reflection client...
-	if a.neighbor.IBGP && a.neighbor.RouteReflectorClient {
+	if a.sessionAttrs.IBGP && a.sessionAttrs.RouteReflectorClient {
 		/*
 		 * RFC4456 Section 8:
 		 * This attribute will carry the BGP Identifier of the originator of the route in the local AS.
@@ -108,7 +108,7 @@ func (a *AdjRIBOut) bgpChecks(pfx *bnet.Prefix, p *route.Path) (retPath *route.P
 		if p.BGPPath.ClusterList != nil {
 			copy(cList[1:], *p.BGPPath.ClusterList)
 		}
-		cList[0] = a.neighbor.ClusterID
+		cList[0] = a.sessionAttrs.ClusterID
 		p.BGPPath.ClusterList = &cList
 	}
 
@@ -172,7 +172,7 @@ func (a *AdjRIBOut) RemovePath(pfx *bnet.Prefix, p *route.Path) bool {
 }
 
 func (a *AdjRIBOut) removePath(pfx *bnet.Prefix, p *route.Path) bool {
-	if !routingtable.ShouldPropagateUpdate(pfx, p, a.neighbor) {
+	if !routingtable.ShouldPropagateUpdate(pfx, p, &a.sessionAttrs) {
 		return false
 	}
 
@@ -235,13 +235,13 @@ func (a *AdjRIBOut) removePathsForPrefix(pfx *bnet.Prefix) bool {
 }
 
 func (a *AdjRIBOut) isOwnPath(p *route.Path) bool {
-	if p.Type != a.neighbor.Type {
+	if p.Type != a.sessionAttrs.Type {
 		return false
 	}
 
 	switch p.Type {
 	case route.BGPPathType:
-		return p.BGPPath.BGPPathA.Source == a.neighbor.Address
+		return p.BGPPath.BGPPathA.Source == a.sessionAttrs.PeerIP
 	}
 
 	return false

--- a/routingtable/adjRIBOut/adj_rib_out_test.go
+++ b/routingtable/adjRIBOut/adj_rib_out_test.go
@@ -15,16 +15,16 @@ import (
 )
 
 func TestBestPathOnlyEBGP(t *testing.T) {
-	neighborBestOnlyEBGP := &routingtable.Neighbor{
+	sessionAttrsBestOnlyEBGP := routingtable.SessionAttrs{
 		Type:              route.BGPPathType,
-		LocalAddress:      net.IPv4FromOctets(127, 0, 0, 1).Ptr(),
-		Address:           net.IPv4FromOctets(127, 0, 0, 2).Ptr(),
+		LocalIP:           net.IPv4FromOctets(127, 0, 0, 1).Ptr(),
+		PeerIP:            net.IPv4FromOctets(127, 0, 0, 2).Ptr(),
 		IBGP:              false,
 		LocalASN:          41981,
 		RouteServerClient: false,
 	}
 
-	adjRIBOut := New(nil, neighborBestOnlyEBGP, filter.NewAcceptAllFilterChain(), false)
+	adjRIBOut := New(nil, sessionAttrsBestOnlyEBGP, filter.NewAcceptAllFilterChain(), false)
 
 	tests := []struct {
 		name          string
@@ -51,7 +51,7 @@ func TestBestPathOnlyEBGP(t *testing.T) {
 					Type: route.BGPPathType,
 					BGPPath: &route.BGPPath{
 						BGPPathA: &route.BGPPathA{
-							NextHop:   neighborBestOnlyEBGP.LocalAddress,
+							NextHop:   sessionAttrsBestOnlyEBGP.LocalIP,
 							Origin:    0,
 							MED:       0,
 							EBGP:      false,
@@ -62,7 +62,7 @@ func TestBestPathOnlyEBGP(t *testing.T) {
 							types.ASPathSegment{
 								Type: types.ASSequence,
 								ASNs: []uint32{
-									neighborBestOnlyEBGP.LocalASN,
+									sessionAttrsBestOnlyEBGP.LocalASN,
 								},
 							},
 						},
@@ -81,7 +81,7 @@ func TestBestPathOnlyEBGP(t *testing.T) {
 					Type: route.BGPPathType,
 					BGPPath: &route.BGPPath{
 						BGPPathA: &route.BGPPathA{
-							NextHop:   neighborBestOnlyEBGP.LocalAddress,
+							NextHop:   sessionAttrsBestOnlyEBGP.LocalIP,
 							Origin:    0,
 							MED:       1,
 							EBGP:      false,
@@ -92,7 +92,7 @@ func TestBestPathOnlyEBGP(t *testing.T) {
 							types.ASPathSegment{
 								Type: types.ASSequence,
 								ASNs: []uint32{
-									neighborBestOnlyEBGP.LocalASN,
+									sessionAttrsBestOnlyEBGP.LocalASN,
 								},
 							},
 						},
@@ -109,7 +109,7 @@ func TestBestPathOnlyEBGP(t *testing.T) {
 					Type: route.BGPPathType,
 					BGPPath: &route.BGPPath{
 						BGPPathA: &route.BGPPathA{
-							NextHop:   neighborBestOnlyEBGP.LocalAddress,
+							NextHop:   sessionAttrsBestOnlyEBGP.LocalIP,
 							Origin:    0,
 							MED:       0,
 							EBGP:      false,
@@ -120,7 +120,7 @@ func TestBestPathOnlyEBGP(t *testing.T) {
 							types.ASPathSegment{
 								Type: types.ASSequence,
 								ASNs: []uint32{
-									neighborBestOnlyEBGP.LocalASN,
+									sessionAttrsBestOnlyEBGP.LocalASN,
 								},
 							},
 						},
@@ -139,7 +139,7 @@ func TestBestPathOnlyEBGP(t *testing.T) {
 					Type: route.BGPPathType,
 					BGPPath: &route.BGPPath{
 						BGPPathA: &route.BGPPathA{
-							NextHop:   neighborBestOnlyEBGP.LocalAddress,
+							NextHop:   sessionAttrsBestOnlyEBGP.LocalIP,
 							Origin:    0,
 							MED:       0,
 							EBGP:      false,
@@ -150,7 +150,7 @@ func TestBestPathOnlyEBGP(t *testing.T) {
 							types.ASPathSegment{
 								Type: types.ASSequence,
 								ASNs: []uint32{
-									neighborBestOnlyEBGP.LocalASN,
+									sessionAttrsBestOnlyEBGP.LocalASN,
 								},
 							},
 						},
@@ -219,7 +219,7 @@ func TestBestPathOnlyEBGP(t *testing.T) {
 					Type: route.BGPPathType,
 					BGPPath: &route.BGPPath{
 						BGPPathA: &route.BGPPathA{
-							NextHop:   neighborBestOnlyEBGP.LocalAddress,
+							NextHop:   sessionAttrsBestOnlyEBGP.LocalIP,
 							Origin:    0,
 							MED:       0,
 							EBGP:      false,
@@ -230,7 +230,7 @@ func TestBestPathOnlyEBGP(t *testing.T) {
 							types.ASPathSegment{
 								Type: types.ASSequence,
 								ASNs: []uint32{
-									neighborBestOnlyEBGP.LocalASN,
+									sessionAttrsBestOnlyEBGP.LocalASN,
 								},
 							},
 						},
@@ -249,7 +249,7 @@ func TestBestPathOnlyEBGP(t *testing.T) {
 					Type: route.BGPPathType,
 					BGPPath: &route.BGPPath{
 						BGPPathA: &route.BGPPathA{
-							NextHop:   neighborBestOnlyEBGP.LocalAddress,
+							NextHop:   sessionAttrsBestOnlyEBGP.LocalIP,
 							Origin:    0,
 							MED:       0,
 							EBGP:      false,
@@ -260,7 +260,7 @@ func TestBestPathOnlyEBGP(t *testing.T) {
 							types.ASPathSegment{
 								Type: types.ASSequence,
 								ASNs: []uint32{
-									neighborBestOnlyEBGP.LocalASN,
+									sessionAttrsBestOnlyEBGP.LocalASN,
 								},
 							},
 						},
@@ -279,7 +279,7 @@ func TestBestPathOnlyEBGP(t *testing.T) {
 					Type: route.BGPPathType,
 					BGPPath: &route.BGPPath{
 						BGPPathA: &route.BGPPathA{
-							NextHop:   neighborBestOnlyEBGP.LocalAddress,
+							NextHop:   sessionAttrsBestOnlyEBGP.LocalIP,
 							Origin:    0,
 							MED:       0,
 							EBGP:      false,
@@ -290,7 +290,7 @@ func TestBestPathOnlyEBGP(t *testing.T) {
 							types.ASPathSegment{
 								Type: types.ASSequence,
 								ASNs: []uint32{
-									neighborBestOnlyEBGP.LocalASN,
+									sessionAttrsBestOnlyEBGP.LocalASN,
 								},
 							},
 						},
@@ -320,7 +320,7 @@ func TestBestPathOnlyEBGP(t *testing.T) {
 					Type: route.BGPPathType,
 					BGPPath: &route.BGPPath{
 						BGPPathA: &route.BGPPathA{
-							NextHop:   neighborBestOnlyEBGP.LocalAddress,
+							NextHop:   sessionAttrsBestOnlyEBGP.LocalIP,
 							Origin:    0,
 							MED:       0,
 							EBGP:      false,
@@ -331,7 +331,7 @@ func TestBestPathOnlyEBGP(t *testing.T) {
 							types.ASPathSegment{
 								Type: types.ASSequence,
 								ASNs: []uint32{
-									neighborBestOnlyEBGP.LocalASN,
+									sessionAttrsBestOnlyEBGP.LocalASN,
 								},
 							},
 						},
@@ -365,16 +365,16 @@ func TestBestPathOnlyEBGP(t *testing.T) {
 }
 
 func TestBestPathOnlyIBGP(t *testing.T) {
-	neighborBestOnlyEBGP := &routingtable.Neighbor{
+	sessionAttrsBestOnlyEBGP := routingtable.SessionAttrs{
 		Type:              route.BGPPathType,
-		LocalAddress:      net.IPv4FromOctets(127, 0, 0, 1).Ptr(),
-		Address:           net.IPv4FromOctets(127, 0, 0, 2).Ptr(),
+		LocalIP:           net.IPv4FromOctets(127, 0, 0, 1).Ptr(),
+		PeerIP:            net.IPv4FromOctets(127, 0, 0, 2).Ptr(),
 		IBGP:              true,
 		LocalASN:          41981,
 		RouteServerClient: false,
 	}
 
-	adjRIBOut := New(nil, neighborBestOnlyEBGP, filter.NewAcceptAllFilterChain(), false)
+	adjRIBOut := New(nil, sessionAttrsBestOnlyEBGP, filter.NewAcceptAllFilterChain(), false)
 
 	testSteps := []struct {
 		name          string
@@ -596,10 +596,10 @@ func TestBestPathOnlyIBGP(t *testing.T) {
  */
 
 func TestBestPathOnlyRRClient(t *testing.T) {
-	neighborBestOnlyRR := &routingtable.Neighbor{
+	peerAttrsBestOnlyRR := routingtable.SessionAttrs{
 		Type:                 route.BGPPathType,
-		LocalAddress:         net.IPv4FromOctets(127, 0, 0, 1).Ptr(),
-		Address:              net.IPv4FromOctets(127, 0, 0, 2).Ptr(),
+		LocalIP:              net.IPv4FromOctets(127, 0, 0, 1).Ptr(),
+		PeerIP:               net.IPv4FromOctets(127, 0, 0, 2).Ptr(),
 		IBGP:                 true,
 		LocalASN:             41981,
 		RouteServerClient:    false,
@@ -607,7 +607,7 @@ func TestBestPathOnlyRRClient(t *testing.T) {
 		ClusterID:            net.IPv4FromOctets(2, 2, 2, 2).Ptr().ToUint32(),
 	}
 
-	adjRIBOut := New(nil, neighborBestOnlyRR, filter.NewAcceptAllFilterChain(), false)
+	adjRIBOut := New(nil, peerAttrsBestOnlyRR, filter.NewAcceptAllFilterChain(), false)
 
 	tests := []struct {
 		name          string
@@ -640,7 +640,7 @@ func TestBestPathOnlyRRClient(t *testing.T) {
 						},
 						ASPath: &types.ASPath{},
 						ClusterList: &types.ClusterList{
-							neighborBestOnlyRR.ClusterID,
+							peerAttrsBestOnlyRR.ClusterID,
 						},
 					},
 				}),
@@ -694,7 +694,7 @@ func TestBestPathOnlyRRClient(t *testing.T) {
 						UnknownAttributes: nil,
 						PathIdentifier:    0,
 						ClusterList: &types.ClusterList{
-							neighborBestOnlyRR.ClusterID,
+							peerAttrsBestOnlyRR.ClusterID,
 						},
 					},
 				}),
@@ -755,7 +755,7 @@ func TestBestPathOnlyRRClient(t *testing.T) {
 						UnknownAttributes: nil,
 						PathIdentifier:    0,
 						ClusterList: &types.ClusterList{
-							neighborBestOnlyRR.ClusterID,
+							peerAttrsBestOnlyRR.ClusterID,
 						},
 					},
 				}),
@@ -788,7 +788,7 @@ func TestBestPathOnlyRRClient(t *testing.T) {
 						UnknownAttributes: nil,
 						PathIdentifier:    0,
 						ClusterList: &types.ClusterList{
-							neighborBestOnlyRR.ClusterID,
+							peerAttrsBestOnlyRR.ClusterID,
 						},
 					},
 				}),
@@ -849,7 +849,7 @@ func TestBestPathOnlyRRClient(t *testing.T) {
 						},
 						PathIdentifier: 0,
 						ClusterList: &types.ClusterList{
-							neighborBestOnlyRR.ClusterID,
+							peerAttrsBestOnlyRR.ClusterID,
 						},
 					},
 				}),
@@ -876,7 +876,7 @@ func TestBestPathOnlyRRClient(t *testing.T) {
 						},
 						PathIdentifier: 0,
 						ClusterList: &types.ClusterList{
-							neighborBestOnlyRR.ClusterID,
+							peerAttrsBestOnlyRR.ClusterID,
 						},
 					},
 				}),
@@ -918,7 +918,7 @@ func TestBestPathOnlyRRClient(t *testing.T) {
 						UnknownAttributes: nil,
 						PathIdentifier:    0,
 						ClusterList: &types.ClusterList{
-							neighborBestOnlyRR.ClusterID,
+							peerAttrsBestOnlyRR.ClusterID,
 							23,
 						},
 					},
@@ -952,16 +952,16 @@ func TestBestPathOnlyRRClient(t *testing.T) {
  */
 
 func TestAddPathIBGP(t *testing.T) {
-	neighborBestOnlyEBGP := &routingtable.Neighbor{
+	sessionAttrsBestOnlyEBGP := routingtable.SessionAttrs{
 		Type:              route.BGPPathType,
-		LocalAddress:      net.IPv4FromOctets(127, 0, 0, 1).Ptr(),
-		Address:           net.IPv4FromOctets(127, 0, 0, 2).Ptr(),
+		LocalIP:           net.IPv4FromOctets(127, 0, 0, 1).Ptr(),
+		PeerIP:            net.IPv4FromOctets(127, 0, 0, 2).Ptr(),
 		IBGP:              true,
 		LocalASN:          41981,
 		RouteServerClient: false,
 	}
 
-	adjRIBOut := New(nil, neighborBestOnlyEBGP, filter.NewAcceptAllFilterChain(), true)
+	adjRIBOut := New(nil, sessionAttrsBestOnlyEBGP, filter.NewAcceptAllFilterChain(), true)
 
 	tests := []struct {
 		name          string

--- a/routingtable/adjRIBOut/adj_rib_out_test.go
+++ b/routingtable/adjRIBOut/adj_rib_out_test.go
@@ -24,7 +24,7 @@ func TestBestPathOnlyEBGP(t *testing.T) {
 		RouteServerClient: false,
 	}
 
-	adjRIBOut := New(nil, sessionAttrsBestOnlyEBGP, filter.NewAcceptAllFilterChain(), false)
+	adjRIBOut := New(nil, sessionAttrsBestOnlyEBGP, filter.NewAcceptAllFilterChain())
 
 	tests := []struct {
 		name          string
@@ -374,7 +374,7 @@ func TestBestPathOnlyIBGP(t *testing.T) {
 		RouteServerClient: false,
 	}
 
-	adjRIBOut := New(nil, sessionAttrsBestOnlyEBGP, filter.NewAcceptAllFilterChain(), false)
+	adjRIBOut := New(nil, sessionAttrsBestOnlyEBGP, filter.NewAcceptAllFilterChain())
 
 	testSteps := []struct {
 		name          string
@@ -607,7 +607,7 @@ func TestBestPathOnlyRRClient(t *testing.T) {
 		ClusterID:            net.IPv4FromOctets(2, 2, 2, 2).Ptr().ToUint32(),
 	}
 
-	adjRIBOut := New(nil, peerAttrsBestOnlyRR, filter.NewAcceptAllFilterChain(), false)
+	adjRIBOut := New(nil, peerAttrsBestOnlyRR, filter.NewAcceptAllFilterChain())
 
 	tests := []struct {
 		name          string
@@ -959,9 +959,10 @@ func TestAddPathIBGP(t *testing.T) {
 		IBGP:              true,
 		LocalASN:          41981,
 		RouteServerClient: false,
+		AddPathTX:         true,
 	}
 
-	adjRIBOut := New(nil, sessionAttrsBestOnlyEBGP, filter.NewAcceptAllFilterChain(), true)
+	adjRIBOut := New(nil, sessionAttrsBestOnlyEBGP, filter.NewAcceptAllFilterChain())
 
 	tests := []struct {
 		name          string

--- a/routingtable/adjRIBOut/path_id_manager.go
+++ b/routingtable/adjRIBOut/path_id_manager.go
@@ -33,7 +33,7 @@ func (fm *pathIDManager) addPath(p *route.Path) (uint32, error) {
 	}
 
 	if fm.used == maxUint32 {
-		return 0, fmt.Errorf("Out of path IDs")
+		return 0, fmt.Errorf("out of path IDs")
 	}
 
 	fm.last++

--- a/routingtable/client_manager_test.go
+++ b/routingtable/client_manager_test.go
@@ -37,33 +37,21 @@ func (m MockClient) UpdateNewClient(RouteTableClient) error {
 	return nil
 }
 
-func (m MockClient) Register(RouteTableClient) {
-	return
-}
+func (m MockClient) Register(RouteTableClient) {}
 
-func (m MockClient) Unregister(RouteTableClient) {
-	return
-}
+func (m MockClient) Unregister(RouteTableClient) {}
 
 func (m MockClient) RouteCount() int64 {
 	return 0
 }
 
-func (m MockClient) ReplaceFilterChain(c filter.Chain) {
+func (m MockClient) ReplaceFilterChain(c filter.Chain) {}
 
-}
+func (m MockClient) ReplacePath(*net.Prefix, *route.Path, *route.Path) {}
 
-func (m MockClient) ReplacePath(*net.Prefix, *route.Path, *route.Path) {
+func (m MockClient) RefreshRoute(*net.Prefix, []*route.Path) {}
 
-}
-
-func (m MockClient) RefreshRoute(*net.Prefix, []*route.Path) {
-
-}
-
-func (m MockClient) Dispose() {
-
-}
+func (m MockClient) Dispose() {}
 
 func TestClients(t *testing.T) {
 	tests := []struct {

--- a/routingtable/mock_client.go
+++ b/routingtable/mock_client.go
@@ -46,20 +46,14 @@ func (m *RTMockClient) AddPathInitialDump(pfx *net.Prefix, p *route.Path) error 
 }
 
 func (m *RTMockClient) UpdateNewClient(client RouteTableClient) error {
-	return fmt.Errorf("Not implemented")
+	return fmt.Errorf("not implemented")
 }
 
-func (m *RTMockClient) Register(RouteTableClient) {
-	return
-}
+func (m *RTMockClient) Register(RouteTableClient) {}
 
-func (m *RTMockClient) RegisterWithOptions(RouteTableClient, ClientOptions) {
-	return
-}
+func (m *RTMockClient) RegisterWithOptions(RouteTableClient, ClientOptions) {}
 
-func (m *RTMockClient) Unregister(RouteTableClient) {
-	return
-}
+func (m *RTMockClient) Unregister(RouteTableClient) {}
 
 // RemovePath removes the path for prefix `pfx`
 func (m *RTMockClient) RemovePath(pfx *net.Prefix, p *route.Path) bool {

--- a/routingtable/session_attrs.go
+++ b/routingtable/session_attrs.go
@@ -2,13 +2,16 @@ package routingtable
 
 import bnet "github.com/bio-routing/bio-rd/net"
 
-// Neighbor represents the attributes identifying a neighbor relationship
-type Neighbor struct {
-	// Address is the IPv4 address of the neighbor as integer representation
-	Address *bnet.IP
+// SessionAttrs represents the attributes identifying a neighbor relationship
+type SessionAttrs struct {
+	// RouterID is the ID of the local router
+	RouterID uint32
 
-	// Local address is the local address of the BGP TCP connection
-	LocalAddress *bnet.IP
+	// PeerIP is the IP address of the neighbor
+	PeerIP *bnet.IP
+
+	// LocalIP is the local address of the BGP TCP connection
+	LocalIP *bnet.IP
 
 	// Type is the type / protocol used for routing inforation communitation
 	Type uint8
@@ -19,6 +22,9 @@ type Neighbor struct {
 	// Local ASN of session
 	LocalASN uint32
 
+	// Peer ASN for this neighbor
+	PeerASN uint32
+
 	// RouteServerClient indicates if the peer is a route server client
 	RouteServerClient bool
 
@@ -27,4 +33,10 @@ type Neighbor struct {
 
 	// ClusterID is our route reflectors clusterID
 	ClusterID uint32
+
+	// AddPathRX indicates if AddPath receive is active
+	AddPathRX bool
+
+	// RouterIP indicates the IP address of the remote BMP peer (only for BMP)
+	RouterIP bnet.IP
 }

--- a/routingtable/session_attrs.go
+++ b/routingtable/session_attrs.go
@@ -37,6 +37,9 @@ type SessionAttrs struct {
 	// AddPathRX indicates if AddPath receive is active
 	AddPathRX bool
 
+	// AddPathTX indicates if AddPath send is active
+	AddPathTX bool
+
 	// RouterIP indicates the IP address of the remote BMP peer (only for BMP)
 	RouterIP bnet.IP
 }

--- a/routingtable/trie.go
+++ b/routingtable/trie.go
@@ -121,7 +121,7 @@ func (n *node) addPath(pfx *net.Prefix, p *route.Path) (*node, bool) {
 		// Store previous dummy-ness to check if this node became new
 		dummy := n.dummy
 		n.dummy = false
-		return n, dummy == true
+		return n, dummy
 	}
 
 	// is pfx NOT a subnet of this node?

--- a/routingtable/update_helper.go
+++ b/routingtable/update_helper.go
@@ -7,24 +7,24 @@ import (
 )
 
 // ShouldPropagateUpdate performs some default checks and returns if an route update should be propagated to a neighbor
-func ShouldPropagateUpdate(pfx *net.Prefix, p *route.Path, n *Neighbor) bool {
-	return !isOwnPath(p, n) && !isDisallowedByCommunity(p, n)
+func ShouldPropagateUpdate(pfx *net.Prefix, p *route.Path, sa *SessionAttrs) bool {
+	return !isOwnPath(p, sa) && !isDisallowedByCommunity(p, sa)
 }
 
-func isOwnPath(p *route.Path, n *Neighbor) bool {
-	if p.Type != n.Type {
+func isOwnPath(p *route.Path, sa *SessionAttrs) bool {
+	if p.Type != sa.Type {
 		return false
 	}
 
 	switch p.Type {
 	case route.BGPPathType:
-		return p.BGPPath.BGPPathA.Source.Compare(n.Address) == 0
+		return p.BGPPath.BGPPathA.Source.Compare(sa.PeerIP) == 0
 	}
 
 	return false
 }
 
-func isDisallowedByCommunity(p *route.Path, n *Neighbor) bool {
+func isDisallowedByCommunity(p *route.Path, sa *SessionAttrs) bool {
 	if p.BGPPath == nil || (p.BGPPath.Communities != nil && len(*p.BGPPath.Communities) == 0) {
 		return false
 	}
@@ -34,7 +34,7 @@ func isDisallowedByCommunity(p *route.Path, n *Neighbor) bool {
 	}
 
 	for _, com := range *p.BGPPath.Communities {
-		if (com == types.WellKnownCommunityNoExport && !n.IBGP) || com == types.WellKnownCommunityNoAdvertise {
+		if (com == types.WellKnownCommunityNoExport && !sa.IBGP) || com == types.WellKnownCommunityNoAdvertise {
 			return true
 		}
 	}

--- a/routingtable/update_helper_test.go
+++ b/routingtable/update_helper_test.go
@@ -12,10 +12,10 @@ import (
 
 func TestShouldPropagateUpdate(t *testing.T) {
 	tests := []struct {
-		name        string
-		communities string
-		neighbor    Neighbor
-		expected    bool
+		name         string
+		communities  string
+		sessionAttrs SessionAttrs
+		expected     bool
 	}{
 		{
 			name:     "arbitrary path",
@@ -24,9 +24,9 @@ func TestShouldPropagateUpdate(t *testing.T) {
 		{
 			name:        "path was received from this peer before",
 			communities: "(1,2)",
-			neighbor: Neighbor{
-				Type:    route.BGPPathType,
-				Address: bnet.IPv4FromOctets(192, 168, 1, 1).Ptr(),
+			sessionAttrs: SessionAttrs{
+				Type:   route.BGPPathType,
+				PeerIP: bnet.IPv4FromOctets(192, 168, 1, 1).Ptr(),
 			},
 			expected: false,
 		},
@@ -38,7 +38,7 @@ func TestShouldPropagateUpdate(t *testing.T) {
 		{
 			name:        "path with no-export community (iBGP)",
 			communities: "(1,2) (65535,65281)",
-			neighbor: Neighbor{
+			sessionAttrs: SessionAttrs{
 				IBGP: true,
 			},
 			expected: true,
@@ -51,7 +51,7 @@ func TestShouldPropagateUpdate(t *testing.T) {
 		{
 			name:        "path with no-advertise community (iBGP)",
 			communities: "(1,2) (65535,65282)",
-			neighbor: Neighbor{
+			sessionAttrs: SessionAttrs{
 				IBGP: true,
 			},
 			expected: false,
@@ -84,7 +84,7 @@ func TestShouldPropagateUpdate(t *testing.T) {
 				},
 			}
 
-			res := ShouldPropagateUpdate(pfx, pa, &test.neighbor)
+			res := ShouldPropagateUpdate(pfx, pa, &test.sessionAttrs)
 			assert.Equal(t, test.expected, res)
 		})
 	}


### PR DESCRIPTION
- Deprecate Neighbor and PeerParams in favor of SessionAttrs
- Merge AddPathTX parameter of AdjRIBOut into SessionAttrs
- Split export checks for iBGP and eBGP paths
- Resolve some nits from go-staticcheck
- Remove internal duplication of attrs within AdjRIBIn

This superseeds #348 with a better name