### PR TITLE
Improve BMP peer handling for dynamci peers

### DIFF
--- a/cmd/ris/main.go
+++ b/cmd/ris/main.go
@@ -58,7 +58,7 @@ func main() {
 			log.Errorf("unable to convert %q to net.IP", r.Address)
 			os.Exit(1)
 		}
-		b.AddRouter(ip, r.Port, r.Passive)
+		b.AddRouter(ip, r.Port, r.Passive, false)
 	}
 
 	s := risserver.NewServer(b)

--- a/examples/bmp/main_bmp.go
+++ b/examples/bmp/main_bmp.go
@@ -17,7 +17,7 @@ func main() {
 	b := server.NewServer(server.BMPServerConfig{
 		KeepalivePeriod: time.Second,
 	})
-	b.AddRouter(net.IP{10, 0, 255, 1}, 30119, false)
+	b.AddRouter(net.IP{10, 0, 255, 1}, 30119, false, false)
 
 	go func() {
 		for {

--- a/protocols/bgp/server/bmp_server_test.go
+++ b/protocols/bgp/server/bmp_server_test.go
@@ -16,7 +16,7 @@ func TestBMPServer(t *testing.T) {
 	rtr := newRouter(net.IP{10, 0, 255, 1}, 30119, false, &adjRIBInFactory{})
 	_, pipe := net.Pipe()
 	rtr.con = pipe
-	srv.addRouter(rtr)
+	srv.routers[rtr.address.String()] = rtr
 
 	init := []byte{
 		3,           // Version


### PR DESCRIPTION
Make sure a BMP peer is only added once, and we purge dynamic peers which went away with sending an init message.