### PR TITLE
Abstract logger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,12 +20,13 @@ coverage.txt
 
 # 'go build' binary
 /cmd/bio-rd/bio-rd
-examples/bgp
-examples/bmp
-examples/fib/fib
-examples/device/device
-cmd/ris/ris
-benchmarks/bgp/learning/learning
+/cmd/bio-rdc/bio-rdc
+/cmd/ris-mirror/ris-mirror
+/cmd/ris/ris
+/cmd/riscli/riscli
+/examples/bgp/bgp
+/examples/bmp/bmp
+/examples/kernel
 
 # bazel directories
 /bazel-*

--- a/README.md
+++ b/README.md
@@ -23,12 +23,6 @@ cd examples/bgp/ && go build
 cd examples/bmp/ && go build
 ```
 
-#### Device
-
-```bash
-cd examples/device && go build
-```
-
 ### Run Tests
 
 ```bash

--- a/cmd/bio-rd/config/isis.go
+++ b/cmd/bio-rd/config/isis.go
@@ -16,7 +16,7 @@ type ISIS struct {
 	LSPLifetime uint16           `yaml:"lsp_lifetime"`
 }
 
-//ISISLevel level config
+// ISISLevel level config
 type ISISLevel struct {
 	Disable               bool   `yaml:"disable"`
 	AuthenticationKey     string `yaml:"authentication_key"`

--- a/cmd/bio-rd/is-is.go
+++ b/cmd/bio-rd/is-is.go
@@ -8,7 +8,7 @@ import (
 	"github.com/bio-routing/bio-rd/cmd/bio-rd/config"
 	"github.com/bio-routing/bio-rd/protocols/isis/server"
 	"github.com/bio-routing/bio-rd/protocols/isis/types"
-	log "github.com/sirupsen/logrus"
+	"github.com/bio-routing/bio-rd/util/log"
 )
 
 func configureProtocolsISIS(isis *config.ISIS) error {

--- a/cmd/bio-rdc/main.go
+++ b/cmd/bio-rdc/main.go
@@ -11,7 +11,8 @@ import (
 	bnet "github.com/bio-routing/bio-rd/net"
 	bgpapi "github.com/bio-routing/bio-rd/protocols/bgp/api"
 	"github.com/bio-routing/bio-rd/route"
-	log "github.com/sirupsen/logrus"
+	"github.com/bio-routing/bio-rd/util/log"
+	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 )
 
@@ -23,6 +24,10 @@ var (
 
 func main() {
 	flag.Parse()
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.DebugLevel)
+	log.SetLogger(log.NewLogrusWrapper(logger))
 
 	conn, err := grpc.Dial(*bioAddr, grpc.WithInsecure())
 	if err != nil {

--- a/cmd/ris-mirror/main.go
+++ b/cmd/ris-mirror/main.go
@@ -12,9 +12,10 @@ import (
 	prom_grpc_cm "github.com/bio-routing/bio-rd/metrics/grpc/clientmanager/adapter/prom"
 	prom_ris_mirror "github.com/bio-routing/bio-rd/metrics/ris-mirror/adapter/prom"
 	"github.com/bio-routing/bio-rd/util/grpc/clientmanager"
+	"github.com/bio-routing/bio-rd/util/log"
 	"github.com/bio-routing/bio-rd/util/servicewrapper"
 	"github.com/prometheus/client_golang/prometheus"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/keepalive"
 )
@@ -30,9 +31,14 @@ var (
 func main() {
 	flag.Parse()
 
+	logger := logrus.New()
+	logger.SetLevel(logrus.DebugLevel)
+	log.SetLogger(log.NewLogrusWrapper(logger))
+
 	cfg, err := config.LoadConfig(*configFilePath)
 	if err != nil {
-		log.WithError(err).Fatal("Failed to load config")
+		log.WithError(err).Error("Failed to load config")
+		os.Exit(1)
 	}
 
 	grpcClientManager := clientmanager.New()
@@ -44,7 +50,8 @@ func main() {
 		}))
 
 		if err != nil {
-			log.WithError(err).Fatal("GRPC clientmanager add failed")
+			log.WithError(err).Error("GRPC clientmanager add failed")
+			os.Exit(1)
 		}
 	}
 
@@ -83,6 +90,7 @@ func main() {
 
 	pb.RegisterRoutingInformationServiceServer(srv.GRPC(), s)
 	if err := srv.Serve(); err != nil {
-		log.Fatalf("failed to start server: %v", err)
+		log.Errorf("failed to start server: %v", err)
+		os.Exit(1)
 	}
 }

--- a/cmd/riscli/dump_loc_rib.go
+++ b/cmd/riscli/dump_loc_rib.go
@@ -7,7 +7,7 @@ import (
 	"os"
 
 	pb "github.com/bio-routing/bio-rd/cmd/ris/api"
-	log "github.com/sirupsen/logrus"
+	"github.com/bio-routing/bio-rd/util/log"
 	"github.com/urfave/cli"
 	"google.golang.org/grpc"
 )

--- a/cmd/riscli/lpm.go
+++ b/cmd/riscli/lpm.go
@@ -7,7 +7,7 @@ import (
 
 	pb "github.com/bio-routing/bio-rd/cmd/ris/api"
 	bnet "github.com/bio-routing/bio-rd/net"
-	log "github.com/sirupsen/logrus"
+	"github.com/bio-routing/bio-rd/util/log"
 	"github.com/urfave/cli"
 	"google.golang.org/grpc"
 )
@@ -32,7 +32,8 @@ func NewLPMCommand() cli.Command {
 
 		ipAddr, err := bnet.IPFromString(c.String("ip"))
 		if err != nil {
-			log.Fatalf("Unable to parse address: %v", err)
+			log.Errorf("Unable to parse address: %v", err)
+			os.Exit(1)
 		}
 
 		pfxLen := uint8(32)
@@ -44,7 +45,8 @@ func NewLPMCommand() cli.Command {
 		client := pb.NewRoutingInformationServiceClient(conn)
 		err = lpm(client, c.GlobalString("router"), c.GlobalUint64("vrf_id"), c.GlobalString("vrf"), pfx)
 		if err != nil {
-			log.Fatalf("LPM failed: %v", err)
+			log.Errorf("LPM failed: %v", err)
+			os.Exit(1)
 		}
 
 		return nil

--- a/cmd/riscli/main.go
+++ b/cmd/riscli/main.go
@@ -3,8 +3,9 @@ package main
 import (
 	"os"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
+
+	"github.com/bio-routing/bio-rd/util/log"
 )
 
 func main() {
@@ -42,7 +43,7 @@ func main() {
 
 	err := app.Run(os.Args)
 	if err != nil {
-		log.Error(err)
+		log.Error(err.Error())
 		os.Exit(1)
 	}
 }

--- a/cmd/riscli/observe_rib.go
+++ b/cmd/riscli/observe_rib.go
@@ -7,7 +7,7 @@ import (
 	"os"
 
 	pb "github.com/bio-routing/bio-rd/cmd/ris/api"
-	log "github.com/sirupsen/logrus"
+	"github.com/bio-routing/bio-rd/util/log"
 	"github.com/urfave/cli"
 	"google.golang.org/grpc"
 )

--- a/examples/bgp/main.go
+++ b/examples/bgp/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"log"
 	"net/http"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -23,10 +22,10 @@ func strAddr(s string) uint32 {
 func main() {
 	logrus.Printf("This is a BGP speaker\n")
 
-	b := server.NewBGPServer(0, []string{":"})
+	b := server.NewBGPServer(0, []string{"127.0.0.1:0"})
 	v, err := vrf.New("master", 0)
 	if err != nil {
-		log.Fatal(err)
+		logrus.Fatal(err)
 	}
 
 	go startMetricsEndpoint(b)

--- a/examples/bgp/main_ipv4.go
+++ b/examples/bgp/main_ipv4.go
@@ -14,7 +14,7 @@ import (
 	"github.com/bio-routing/bio-rd/protocols/bgp/server"
 	"github.com/bio-routing/bio-rd/routingtable"
 	"github.com/bio-routing/bio-rd/routingtable/filter"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 
 	api "github.com/bio-routing/bio-rd/protocols/bgp/api"
 )
@@ -24,7 +24,7 @@ func startServer(b server.BGPServer, v *vrf.VRF) {
 
 	lis, err := net.Listen("tcp", ":1337")
 	if err != nil {
-		log.Fatalf("failed to listen: %v", err)
+		logrus.Fatalf("failed to listen: %v", err)
 	}
 	grpcServer := grpc.NewServer()
 	api.RegisterBgpServiceServer(grpcServer, apiSrv)
@@ -32,7 +32,7 @@ func startServer(b server.BGPServer, v *vrf.VRF) {
 
 	err = b.Start()
 	if err != nil {
-		log.Fatalf("Unable to start BGP server: %v", err)
+		logrus.Fatalf("Unable to start BGP server: %v", err)
 	}
 
 	b.AddPeer(server.PeerConfig{

--- a/examples/kernel/main.go
+++ b/examples/kernel/main.go
@@ -8,13 +8,13 @@ import (
 	"github.com/bio-routing/bio-rd/protocols/kernel"
 	"github.com/bio-routing/bio-rd/route"
 	"github.com/bio-routing/bio-rd/routingtable/vrf"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 func main() {
 	vrf, err := vrf.New("inet.0", 0)
 	if err != nil {
-		log.Errorf("unable to create VRF: %v", err)
+		logrus.Errorf("unable to create VRF: %v", err)
 		os.Exit(1)
 	}
 
@@ -28,7 +28,7 @@ func main() {
 
 	k, err := kernel.New()
 	if err != nil {
-		log.Errorf("unable to create protocol kernel: %v", err)
+		logrus.Errorf("unable to create protocol kernel: %v", err)
 		os.Exit(1)
 	}
 	defer k.Dispose()

--- a/metrics/bgp/adapter/prom/bgp_prom_adapter.go
+++ b/metrics/bgp/adapter/prom/bgp_prom_adapter.go
@@ -1,14 +1,13 @@
 package prom
 
 import (
-	"fmt"
 	"strconv"
 	"time"
 
 	"github.com/bio-routing/bio-rd/protocols/bgp/metrics"
 	"github.com/bio-routing/bio-rd/protocols/bgp/server"
+	"github.com/bio-routing/bio-rd/util/log"
 	"github.com/prometheus/client_golang/prometheus"
-	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -109,7 +108,7 @@ func DescribeRouter(ch chan<- *prometheus.Desc) {
 func (c *bgpCollector) Collect(ch chan<- prometheus.Metric) {
 	m, err := c.server.Metrics()
 	if err != nil {
-		log.Error(fmt.Errorf("Could not retrieve metrics from BGP server: %w", err))
+		log.WithError(err).Error("Could not retrieve metrics from BGP server")
 		return
 	}
 

--- a/metrics/bmp/adapter/prom/bmp_prom_adapter.go
+++ b/metrics/bmp/adapter/prom/bmp_prom_adapter.go
@@ -1,15 +1,13 @@
 package prom
 
 import (
-	"fmt"
-
 	"github.com/bio-routing/bio-rd/protocols/bgp/metrics"
 	"github.com/bio-routing/bio-rd/protocols/bgp/server"
 	"github.com/prometheus/client_golang/prometheus"
 
 	bgp_prom "github.com/bio-routing/bio-rd/metrics/bgp/adapter/prom"
 	vrf_prom "github.com/bio-routing/bio-rd/metrics/vrf/adapter/prom"
-	log "github.com/sirupsen/logrus"
+	"github.com/bio-routing/bio-rd/util/log"
 )
 
 const (
@@ -69,7 +67,7 @@ func (c *bmpCollector) Describe(ch chan<- *prometheus.Desc) {
 func (c *bmpCollector) Collect(ch chan<- prometheus.Metric) {
 	m, err := c.server.Metrics()
 	if err != nil {
-		log.Error(fmt.Errorf("Could not retrieve metrics from BMP server: %w", err))
+		log.WithError(err).Error("Could not retrieve metrics from BMP server")
 		return
 	}
 

--- a/protocols/bgp/server/bgp_api_test.go
+++ b/protocols/bgp/server/bgp_api_test.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"log"
 	"net"
 	"testing"
 	"time"
@@ -269,7 +268,7 @@ func TestDumpRIBInOut(t *testing.T) {
 		api.RegisterBgpServiceServer(s, test.apisrv)
 		go func() {
 			if err := s.Serve(lis); err != nil {
-				log.Fatalf("Server exited with error: %v", err)
+				t.Logf("Server exited with error: %v", err)
 			}
 		}()
 
@@ -324,7 +323,7 @@ func TestDumpRIBInOut(t *testing.T) {
 		api.RegisterBgpServiceServer(s, test.apisrv)
 		go func() {
 			if err := s.Serve(lis); err != nil {
-				log.Fatalf("Server exited with error: %v", err)
+				t.Logf("Server exited with error: %v", err)
 			}
 		}()
 

--- a/protocols/bgp/server/bmp_router_test.go
+++ b/protocols/bgp/server/bmp_router_test.go
@@ -13,6 +13,8 @@ package server
 		},
 	}
 
+        logger := logrus.New()
+        SetLogger(log.NewLogrusWrapper(logger))
 	for _, test := range tests {
 		addr := net.IP{10, 20, 30, 40}
 		port := uint16(123)
@@ -22,7 +24,7 @@ package server
 
 		r := newRouter(addr, port, rib4, rib6)
 		buf := bytes.NewBuffer(nil)
-		r.logger.Out = buf
+		logger.Out = buf
 		go r.serve(conA)
 
 		conB.Write(test.msg)
@@ -375,7 +377,6 @@ func TestProcessRouteMonitoringMsg(t *testing.T) {
 			name: "Unknown peer address",
 			r: &router{
 				address: net.IP{10, 20, 30, 40},
-				logger:  log.New(),
 			},
 			msg: &bmppkt.RouteMonitoringMsg{
 				PerPeerHeader: &bmppkt.PerPeerHeader{
@@ -388,12 +389,12 @@ func TestProcessRouteMonitoringMsg(t *testing.T) {
 		},
 	}
 
+        logger := logrus.New()
+        SetLogger(log.NewLogrusWrapper(logger))
 	for _, test := range tests {
 		logBuf := bytes.NewBuffer(nil)
-		test.r.logger.Out = logBuf
-		test.r.logger.Formatter = biotesting.NewLogFormatter()
-
-		test.expected.logger = test.r.logger
+		logger.Out = logBuf
+		logger.Formatter = biotesting.NewLogFormatter()
 
 		test.r.processRouteMonitoringMsg(test.msg)
 
@@ -417,7 +418,6 @@ func TestProcessInitiationMsg(t *testing.T) {
 			name: "Test #1",
 			r: &router{
 				address: net.IP{10, 20, 30, 40},
-				logger:  log.New(),
 			},
 			msg: &bmppkt.InitiationMessage{
 				TLVs: []*bmppkt.InformationTLV{
@@ -439,10 +439,12 @@ func TestProcessInitiationMsg(t *testing.T) {
 		},
 	}
 
+        logger := logrus.New()
+        SetLogger(log.NewLogrusWrapper(logger))
 	for _, test := range tests {
 		logBuf := bytes.NewBuffer(nil)
-		test.r.logger.Out = logBuf
-		test.r.logger.Formatter = biotesting.NewLogFormatter()
+		logger.Out = logBuf
+		logger.Formatter = biotesting.NewLogFormatter()
 
 		test.r.processInitiationMsg(test.msg)
 
@@ -463,7 +465,6 @@ func TestProcessTerminationMsg(t *testing.T) {
 			r: &router{
 				con:     &biotesting.MockConn{},
 				address: net.IP{10, 20, 30, 40},
-				logger:  log.New(),
 				neighbors: map[[16]byte]*neighbor{
 					{1, 2, 3}: {},
 				},
@@ -490,7 +491,6 @@ func TestProcessTerminationMsg(t *testing.T) {
 			r: &router{
 				con:     &biotesting.MockConn{},
 				address: net.IP{10, 20, 30, 40},
-				logger:  log.New(),
 				neighbors: map[[16]byte]*neighbor{
 					{1, 2, 3}: {},
 				},
@@ -530,12 +530,12 @@ func TestProcessTerminationMsg(t *testing.T) {
 		},
 	}
 
+        logger := logrus.New()
+        SetLogger(log.NewLogrusWrapper(logger))
 	for _, test := range tests {
 		logBuf := bytes.NewBuffer(nil)
-		test.r.logger.Out = logBuf
-		test.r.logger.Formatter = biotesting.NewLogFormatter()
-
-		test.expected.logger = test.r.logger
+		logger.Out = logBuf
+		logger.Formatter = biotesting.NewLogFormatter()
 
 		test.r.processTerminationMsg(test.msg)
 
@@ -556,7 +556,6 @@ func TestProcessPeerDownNotification(t *testing.T) {
 			name: "Peer down notification for existing peer",
 			r: &router{
 				address: net.IP{10, 20, 30, 40},
-				logger:  log.New(),
 				neighbors: map[[16]byte]*neighbor{
 					{1, 2, 3}: {},
 				},
@@ -576,7 +575,6 @@ func TestProcessPeerDownNotification(t *testing.T) {
 			name: "Peer down notification for non-existing peer",
 			r: &router{
 				address: net.IP{10, 20, 30, 40},
-				logger:  log.New(),
 				neighbors: map[[16]byte]*neighbor{
 					{1, 2, 3}: {},
 				},
@@ -596,12 +594,12 @@ func TestProcessPeerDownNotification(t *testing.T) {
 		},
 	}
 
+        logger := logrus.New()
+        SetLogger(log.NewLogrusWrapper(logger))
 	for _, test := range tests {
 		logBuf := bytes.NewBuffer(nil)
-		test.r.logger.Out = logBuf
-		test.r.logger.Formatter = biotesting.NewLogFormatter()
-
-		test.expected.logger = test.r.logger
+		logger.Out = logBuf
+		logger.Formatter = biotesting.NewLogFormatter()
 
 		test.r.processPeerDownNotification(test.msg)
 

--- a/protocols/bgp/server/bmp_server.go
+++ b/protocols/bgp/server/bmp_server.go
@@ -11,9 +11,8 @@ import (
 	"github.com/bio-routing/bio-rd/protocols/bgp/metrics"
 	bmppkt "github.com/bio-routing/bio-rd/protocols/bmp/packet"
 	"github.com/bio-routing/bio-rd/routingtable"
+	"github.com/bio-routing/bio-rd/util/log"
 	"github.com/bio-routing/tflow2/convert"
-
-	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -178,7 +177,7 @@ func (b *BMPServer) handleConnection(c net.Conn, r *Router, passive bool, dynami
 		if dynamic && r.counters.initiationMessages == 0 {
 			defer b.RemoveRouter(r.address)
 
-			r.logger.WithFields(log.Fields{
+			log.WithFields(log.Fields{
 				"component": "bmp_server",
 				"address":   c.RemoteAddr().String(),
 				"router":    r.Name(),
@@ -187,7 +186,7 @@ func (b *BMPServer) handleConnection(c net.Conn, r *Router, passive bool, dynami
 			return err
 
 		} else {
-			r.logger.WithFields(log.Fields{
+			log.WithFields(log.Fields{
 				"component": "bmp_server",
 				"address":   c.RemoteAddr().String(),
 				"router":    r.Name(),

--- a/protocols/bgp/server/fsm.go
+++ b/protocols/bgp/server/fsm.go
@@ -11,7 +11,7 @@ import (
 	"github.com/bio-routing/bio-rd/net/tcp"
 	"github.com/bio-routing/bio-rd/protocols/bgp/packet"
 	"github.com/bio-routing/bio-rd/routingtable/filter"
-	log "github.com/sirupsen/logrus"
+	"github.com/bio-routing/bio-rd/util/log"
 )
 
 const (

--- a/protocols/bgp/server/fsm_established.go
+++ b/protocols/bgp/server/fsm_established.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/bio-routing/bio-rd/protocols/bgp/packet"
-	log "github.com/sirupsen/logrus"
+	"github.com/bio-routing/bio-rd/util/log"
 )
 
 type establishedState struct {
@@ -196,12 +196,12 @@ func (s *establishedState) update(u *packet.BGPUpdate, bmpPostPolicy bool, times
 	switch afi {
 	case packet.AFIIPv4:
 		if s.fsm.ipv4Unicast == nil {
-			log.Warnf("Received update for family IPv4 unicast, but this family is not configured.")
+			log.Info("Received update for family IPv4 unicast, but this family is not configured.")
 		}
 
 	case packet.AFIIPv6:
 		if s.fsm.ipv6Unicast == nil {
-			log.Warnf("Received update for family IPv6 unicast, but this family is not configured.")
+			log.Info("Received update for family IPv6 unicast, but this family is not configured.")
 		}
 
 	}

--- a/protocols/bgp/server/server.go
+++ b/protocols/bgp/server/server.go
@@ -11,8 +11,8 @@ import (
 
 	bnet "github.com/bio-routing/bio-rd/net"
 	"github.com/bio-routing/bio-rd/protocols/bgp/metrics"
+	"github.com/bio-routing/bio-rd/util/log"
 	bnetutils "github.com/bio-routing/bio-rd/util/net"
-	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -162,7 +162,7 @@ func (b *bgpServer) incomingConnectionWorker() {
 			c.Close()
 			log.WithFields(log.Fields{
 				"source": c.RemoteAddr(),
-			}).Warning("TCP connection from unknown source")
+			}).Info("TCP connection from unknown source")
 			continue
 		}
 
@@ -170,7 +170,9 @@ func (b *bgpServer) incomingConnectionWorker() {
 			"source": c.RemoteAddr(),
 		}).Info("Incoming TCP connection")
 
-		log.WithField("Peer", peerAddr).Debug("Sending incoming TCP connection to fsm for peer")
+		log.WithFields(log.Fields{
+			"peer": peerAddr,
+		}).Debug("Sending incoming TCP connection to fsm for peer")
 		fsm := NewActiveFSM(peer)
 		fsm.state = newActiveState(fsm)
 		fsm.startConnectRetryTimer()

--- a/protocols/bgp/server/tcplistener.go
+++ b/protocols/bgp/server/tcplistener.go
@@ -4,7 +4,7 @@ import (
 	"net"
 
 	"github.com/bio-routing/bio-rd/net/tcp"
-	log "github.com/sirupsen/logrus"
+	"github.com/bio-routing/bio-rd/util/log"
 )
 
 const (
@@ -40,10 +40,9 @@ func NewTCPListener(addr string, ch chan net.Conn) (*TCPListener, error) {
 			conn, err := tl.l.AcceptTCP()
 			if err != nil {
 				close(tl.closeCh)
-				log.WithFields(log.Fields{
+				log.WithError(err).WithFields(log.Fields{
 					"Topic": "Peer",
-					"Error": err,
-				}).Warn("Failed to AcceptTCP")
+				}).Error("Failed to AcceptTCP")
 				return err
 			}
 			ch <- conn

--- a/protocols/bgp/server/update_helper.go
+++ b/protocols/bgp/server/update_helper.go
@@ -5,8 +5,7 @@ import (
 	"io"
 
 	"github.com/bio-routing/bio-rd/protocols/bgp/packet"
-
-	log "github.com/sirupsen/logrus"
+	"github.com/bio-routing/bio-rd/util/log"
 )
 
 func serializeAndSendUpdate(out io.Writer, update serializeAbleUpdate, opt *packet.EncodeOptions) error {

--- a/protocols/bgp/server/update_sender.go
+++ b/protocols/bgp/server/update_sender.go
@@ -13,7 +13,7 @@ import (
 	"github.com/bio-routing/bio-rd/route"
 	"github.com/bio-routing/bio-rd/routingtable"
 	"github.com/bio-routing/bio-rd/routingtable/filter"
-	log "github.com/sirupsen/logrus"
+	"github.com/bio-routing/bio-rd/util/log"
 )
 
 // UpdateSender converts table changes into BGP update messages
@@ -351,13 +351,13 @@ func (u *UpdateSender) withdrawPrefixMultiProtocol(out io.Writer, pfx *bnet.Pref
 
 // UpdateNewClient does nothing
 func (u *UpdateSender) UpdateNewClient(client routingtable.RouteTableClient) error {
-	log.Warningf("BGP Update Sender: UpdateNewClient not implemented")
+	log.Error("BGP Update Sender: UpdateNewClient not implemented")
 	return nil
 }
 
 // RouteCount returns the number of stored routes
 func (u *UpdateSender) RouteCount() int64 {
-	log.Warningf("BGP Update Sender: RouteCount not implemented")
+	log.Error("BGP Update Sender: RouteCount not implemented")
 	return 0
 }
 

--- a/protocols/device/server.go
+++ b/protocols/device/server.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"sync"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/bio-routing/bio-rd/util/log"
 )
 
 // Updater is a device updater interface

--- a/protocols/device/server_linux.go
+++ b/protocols/device/server_linux.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	bnet "github.com/bio-routing/bio-rd/net"
-	log "github.com/sirupsen/logrus"
+	"github.com/bio-routing/bio-rd/util/log"
 	"github.com/vishvananda/netlink"
 )
 
@@ -124,7 +124,7 @@ func (o *osAdapterLinux) processAddrUpdate(au *netlink.AddrUpdate) {
 	defer o.srv.devicesMu.RUnlock()
 
 	if _, ok := o.srv.devices[uint64(au.LinkIndex)]; !ok {
-		log.Warningf("Received address update for non existent device index %d", au.LinkIndex)
+		log.Infof("Received address update for non existent device index %d", au.LinkIndex)
 		return
 	}
 

--- a/protocols/isis/server/hello_sender.go
+++ b/protocols/isis/server/hello_sender.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/bio-routing/bio-rd/protocols/isis/packet"
 	"github.com/bio-routing/bio-rd/protocols/isis/types"
+	"github.com/bio-routing/bio-rd/util/log"
 	"github.com/bio-routing/tflow2/convert"
-	log "github.com/sirupsen/logrus"
 )
 
 func (nifa *netIfa) p2pHelloSender() {

--- a/protocols/isis/server/lsdb.go
+++ b/protocols/isis/server/lsdb.go
@@ -5,9 +5,8 @@ import (
 
 	"github.com/bio-routing/bio-rd/protocols/isis/packet"
 	"github.com/bio-routing/bio-rd/protocols/isis/types"
+	"github.com/bio-routing/bio-rd/util/log"
 	btime "github.com/bio-routing/bio-rd/util/time"
-
-	log "github.com/sirupsen/logrus"
 )
 
 type lsdb struct {

--- a/protocols/isis/server/neighbor.go
+++ b/protocols/isis/server/neighbor.go
@@ -8,9 +8,8 @@ import (
 	"github.com/bio-routing/bio-rd/net/ethernet"
 	"github.com/bio-routing/bio-rd/protocols/isis/packet"
 	"github.com/bio-routing/bio-rd/protocols/isis/types"
+	"github.com/bio-routing/bio-rd/util/log"
 	btime "github.com/bio-routing/bio-rd/util/time"
-
-	log "github.com/sirupsen/logrus"
 )
 
 const (

--- a/protocols/isis/server/neighbor_manager.go
+++ b/protocols/isis/server/neighbor_manager.go
@@ -9,7 +9,7 @@ import (
 	"github.com/bio-routing/bio-rd/net/ethernet"
 	"github.com/bio-routing/bio-rd/protocols/isis/packet"
 	"github.com/bio-routing/bio-rd/protocols/isis/types"
-	log "github.com/sirupsen/logrus"
+	"github.com/bio-routing/bio-rd/util/log"
 )
 
 type neighborManager struct {

--- a/protocols/isis/server/net_ifa.go
+++ b/protocols/isis/server/net_ifa.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/bio-routing/bio-rd/net/ethernet"
 	"github.com/bio-routing/bio-rd/protocols/device"
+	"github.com/bio-routing/bio-rd/util/log"
 	btime "github.com/bio-routing/bio-rd/util/time"
-	log "github.com/sirupsen/logrus"
 )
 
 var (

--- a/protocols/isis/server/net_ifa_manager.go
+++ b/protocols/isis/server/net_ifa_manager.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"sync"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/bio-routing/bio-rd/util/log"
 )
 
 type netIfaManager struct {

--- a/protocols/isis/server/net_ifa_rx.go
+++ b/protocols/isis/server/net_ifa_rx.go
@@ -7,7 +7,7 @@ import (
 	"github.com/bio-routing/bio-rd/net/ethernet"
 	"github.com/bio-routing/bio-rd/protocols/isis/packet"
 	"github.com/bio-routing/bio-rd/protocols/isis/types"
-	log "github.com/sirupsen/logrus"
+	"github.com/bio-routing/bio-rd/util/log"
 )
 
 func (nifa *netIfa) receiver() {

--- a/protocols/isis/server/server.go
+++ b/protocols/isis/server/server.go
@@ -27,7 +27,7 @@ type ISISServer interface {
 	GetLSDB() []*LSDBEntry
 }
 
-//Server represents an ISIS server
+// Server represents an ISIS server
 type Server struct {
 	running            bool
 	runningMu          sync.Mutex

--- a/risclient/risclient.go
+++ b/risclient/risclient.go
@@ -7,9 +7,8 @@ import (
 
 	risapi "github.com/bio-routing/bio-rd/cmd/ris/api"
 	routeapi "github.com/bio-routing/bio-rd/route/api"
+	"github.com/bio-routing/bio-rd/util/log"
 	"google.golang.org/grpc"
-
-	log "github.com/sirupsen/logrus"
 )
 
 // Client is a client interface

--- a/route/bgp_path_manager.go
+++ b/route/bgp_path_manager.go
@@ -1,8 +1,9 @@
 package route
 
 import (
-	"log"
 	"sync"
+
+	"github.com/bio-routing/bio-rd/util/log"
 )
 
 // BGPPathManager is a component used to deduplicate BGP Path objects
@@ -56,7 +57,7 @@ func (m *BGPPathManager) RemovePath(p BGPPath) {
 	defer m.mu.Unlock()
 
 	if m.lookup(p) == nil {
-		log.Fatalf("Tried to remove non-existent BGPPath: %v", p)
+		log.Errorf("Tried to remove non-existent BGPPath: %v", p)
 		return
 	}
 

--- a/routingtable/adjRIBIn/adj_rib_in.go
+++ b/routingtable/adjRIBIn/adj_rib_in.go
@@ -8,7 +8,7 @@ import (
 	"github.com/bio-routing/bio-rd/route"
 	"github.com/bio-routing/bio-rd/routingtable"
 	"github.com/bio-routing/bio-rd/routingtable/filter"
-	log "github.com/sirupsen/logrus"
+	"github.com/bio-routing/bio-rd/util/log"
 )
 
 // AdjRIBIn represents an Adjacency RIB In as described in RFC4271
@@ -123,7 +123,9 @@ func (a *AdjRIBIn) UpdateNewClient(client routingtable.RouteTableClient) error {
 
 			err := client.AddPathInitialDump(route.Prefix(), path)
 			if err != nil {
-				log.WithField("Sender", "AdjRIBOutAddPath").WithError(err).Error("Could not send update to client")
+				log.WithFields(log.Fields{
+					"sender": "AdjRIBOutAddPath"},
+				).WithError(err).Error("Could not send update to client")
 			}
 		}
 	}

--- a/routingtable/adjRIBOut/adj_rib_out.go
+++ b/routingtable/adjRIBOut/adj_rib_out.go
@@ -11,7 +11,7 @@ import (
 	"github.com/bio-routing/bio-rd/routingtable"
 	"github.com/bio-routing/bio-rd/routingtable/filter"
 	"github.com/bio-routing/bio-rd/routingtable/locRIB"
-	log "github.com/sirupsen/logrus"
+	"github.com/bio-routing/bio-rd/util/log"
 )
 
 // AdjRIBOut represents an Adjacency RIB Out with BGP add path
@@ -185,7 +185,9 @@ func (a *AdjRIBOut) addPath(pfx *bnet.Prefix, p *route.Path) error {
 	for _, client := range a.clientManager.Clients() {
 		err := client.AddPath(pfx, p)
 		if err != nil {
-			log.WithField("Sender", "AdjRIBOutAddPath").WithError(err).Error("Could not send update to client")
+			log.WithFields(log.Fields{
+				"sender": "AdjRIBOutAddPath",
+			}).WithError(err).Error("Could not send update to client")
 		}
 	}
 	return nil
@@ -222,7 +224,8 @@ func (a *AdjRIBOut) removePath(pfx *bnet.Prefix, p *route.Path) bool {
 
 				_, err := a.pathIDManager.releasePath(p)
 				if err != nil {
-					log.Warningf("Unable to release path for prefix %s: %v", pfx.String(), err)
+					log.WithError(err).
+						Errorf("Unable to release path for prefix %s: %v", pfx.String(), err)
 					return true
 				}
 

--- a/routingtable/locRIB/loc_rib.go
+++ b/routingtable/locRIB/loc_rib.go
@@ -8,8 +8,8 @@ import (
 	"github.com/bio-routing/bio-rd/route"
 	"github.com/bio-routing/bio-rd/routingtable"
 	"github.com/bio-routing/bio-rd/routingtable/filter"
+	"github.com/bio-routing/bio-rd/util/log"
 	"github.com/bio-routing/bio-rd/util/math"
-	log "github.com/sirupsen/logrus"
 )
 
 // LocRIB represents a routing information base

--- a/util/log/log.go
+++ b/util/log/log.go
@@ -1,0 +1,50 @@
+package log
+
+var logger LoggerInterface
+
+// LoggerInterface is the interface used to abstract logging.
+type LoggerInterface interface {
+	Errorf(format string, args ...interface{})
+	Infof(format string, args ...interface{})
+	Debugf(format string, args ...interface{})
+	Error(msg string)
+	Info(msg string)
+	Debug(msg string)
+	WithFields(fields Fields) LoggerInterface
+	WithError(err error) LoggerInterface
+}
+
+// Fields type, used to pass to `WithFields`.
+type Fields map[string]interface{}
+
+// SetLogger changes the global logger to the one provided.
+func SetLogger(l LoggerInterface) {
+	logger = l
+}
+
+// Module-passthrough functions
+
+func Errorf(format string, args ...interface{}) {
+	logger.Errorf(format, args...)
+}
+func Infof(format string, args ...interface{}) {
+	logger.Infof(format, args...)
+}
+func Debugf(format string, args ...interface{}) {
+	logger.Debugf(format, args...)
+}
+func Error(msg string) {
+	logger.Error(msg)
+}
+func Info(msg string) {
+	logger.Info(msg)
+}
+func Debug(msg string) {
+	logger.Debug(msg)
+}
+func WithFields(fields Fields) LoggerInterface {
+	return logger.WithFields(fields)
+}
+func WithError(err error) LoggerInterface {
+	return logger.WithError(err)
+}

--- a/util/log/logrus.go
+++ b/util/log/logrus.go
@@ -1,0 +1,40 @@
+package log
+
+import "github.com/sirupsen/logrus"
+
+func init() {
+	logger = NewLogrusWrapper(logrus.New())
+}
+
+type logrusWrapper struct {
+	logger *logrus.Entry
+}
+
+func NewLogrusWrapper(l *logrus.Logger) LoggerInterface {
+	return logrusWrapper{logrus.NewEntry(l)}
+}
+
+func (lw logrusWrapper) Errorf(format string, args ...interface{}) {
+	lw.logger.Errorf(format, args...)
+}
+func (lw logrusWrapper) Infof(format string, args ...interface{}) {
+	lw.logger.Infof(format, args...)
+}
+func (lw logrusWrapper) Debugf(format string, args ...interface{}) {
+	lw.logger.Debugf(format, args...)
+}
+func (lw logrusWrapper) Error(msg string) {
+	lw.logger.Error(msg)
+}
+func (lw logrusWrapper) Info(msg string) {
+	lw.logger.Info(msg)
+}
+func (lw logrusWrapper) Debug(msg string) {
+	lw.logger.Debug(msg)
+}
+func (lw logrusWrapper) WithFields(fields Fields) LoggerInterface {
+	return logrusWrapper{lw.logger.WithFields(logrus.Fields(fields))}
+}
+func (lw logrusWrapper) WithError(err error) LoggerInterface {
+	return logrusWrapper{lw.logger.WithError(err)}
+}

--- a/util/servicewrapper/grpc.go
+++ b/util/servicewrapper/grpc.go
@@ -14,35 +14,34 @@ import (
 	grpc_ctxtags "github.com/grpc-ecosystem/go-grpc-middleware/tags"
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/reflection"
-
-	log "github.com/sirupsen/logrus"
 )
 
 // CodeToLogrusLevel is the default 0-stor implementation
 // of gRPC return codes to log(rus) levels for server side.
-func codeToLogrusLevel(code codes.Code) log.Level {
+func codeToLogrusLevel(code codes.Code) logrus.Level {
 	if level, ok := _GRPCCodeToLogrusLevelMapping[code]; ok {
 		return level
 	}
-	return log.ErrorLevel
+	return logrus.ErrorLevel
 }
 
-var _GRPCCodeToLogrusLevelMapping = map[codes.Code]log.Level{
-	codes.OK:                 log.DebugLevel,
-	codes.Canceled:           log.DebugLevel,
-	codes.InvalidArgument:    log.DebugLevel,
-	codes.NotFound:           log.DebugLevel,
-	codes.AlreadyExists:      log.DebugLevel,
-	codes.Unauthenticated:    log.InfoLevel,
-	codes.PermissionDenied:   log.InfoLevel,
-	codes.DeadlineExceeded:   log.WarnLevel,
-	codes.ResourceExhausted:  log.WarnLevel,
-	codes.FailedPrecondition: log.WarnLevel,
-	codes.Aborted:            log.WarnLevel,
+var _GRPCCodeToLogrusLevelMapping = map[codes.Code]logrus.Level{
+	codes.OK:                 logrus.DebugLevel,
+	codes.Canceled:           logrus.DebugLevel,
+	codes.InvalidArgument:    logrus.DebugLevel,
+	codes.NotFound:           logrus.DebugLevel,
+	codes.AlreadyExists:      logrus.DebugLevel,
+	codes.Unauthenticated:    logrus.InfoLevel,
+	codes.PermissionDenied:   logrus.InfoLevel,
+	codes.DeadlineExceeded:   logrus.WarnLevel,
+	codes.ResourceExhausted:  logrus.WarnLevel,
+	codes.FailedPrecondition: logrus.WarnLevel,
+	codes.Aborted:            logrus.WarnLevel,
 }
 
 // Server represents an exarpc server wrapper
@@ -64,7 +63,7 @@ func New(grpcPort uint16, h *http.Server, unaryInterceptors []grpc.UnaryServerIn
 		httpSrv: h,
 	}
 
-	logrusEntry := log.NewEntry(log.StandardLogger())
+	logrusEntry := logrus.NewEntry(logrus.StandardLogger())
 	levelOpt := grpc_logrus.WithLevels(codeToLogrusLevel)
 
 	unaryInterceptors = append(unaryInterceptors,
@@ -121,7 +120,7 @@ func (s *Server) Serve() error {
 	wg.Add(1)
 	go func(wg *sync.WaitGroup) {
 		err := s.grpcSrv.srv.Serve(grpcLis)
-		log.Fatalf("GRPC serving failed: %v", err)
+		logrus.Fatalf("GRPC serving failed: %v", err)
 		os.Exit(1)
 		wg.Done()
 	}(&wg)
@@ -131,7 +130,7 @@ func (s *Server) Serve() error {
 	wg.Add(1)
 	go func(wg *sync.WaitGroup) {
 		err := s.httpSrv.ListenAndServe()
-		log.Fatalf("HTTP serving failed: %v", err)
+		logrus.Fatalf("HTTP serving failed: %v", err)
 		os.Exit(1)
 		wg.Done()
 	}(&wg)


### PR DESCRIPTION
Replace direct to Logrus with a proxy exposing an abstract interface
very close to Logrus.

The changes include:

- add the `util/log` module
- replace the import of logrus with the import of this module
- call `SetLogger` at the main entry point (not strictly necessary)
- use `logrus` explicitely at some point

Also, the BMP server is losing its internal logger. It was used for
tests, but these tests are commented. The test has been updated to use
`SetLogger` instead (but it has not been really tested, ideally, it
should be a text fixture undoing the change once the test has run).

Fix #362.