### PR TITLE
BMP: Add a method to get listener local address

### DIFF
--- a/protocols/bgp/server/bmp_server.go
+++ b/protocols/bgp/server/bmp_server.go
@@ -128,6 +128,14 @@ func (b *BMPServer) Listen(addr string) error {
 	}
 }
 
+// LocalAddr returns the local address the server is listening to.
+func (b *BMPServer) LocalAddr() net.Addr {
+	if b.listener != nil {
+		return b.listener.Addr()
+	}
+	return nil
+}
+
 func (b *BMPServer) validateConnection(r *Router, c net.Conn) bool {
 	if !r.passive {
 		log.WithFields(log.Fields{


### PR DESCRIPTION
This is useful when listening on port 0 for testing purpose. We can
get the free port the kernel has allocated to us.