### PR TITLE
BMP: separate Listen() and Serve() into two functions

### DIFF
--- a/cmd/ris/main.go
+++ b/cmd/ris/main.go
@@ -59,6 +59,9 @@ func main() {
 			if err := b.Listen(*bmpListenAddr); err != nil {
 				log.WithError(err).Error("error while starting listener")
 			}
+			if err := b.Serve(); err != nil {
+				log.WithError(err).Error("error while serving connections")
+			}
 		}()
 	}
 	defer b.Close()


### PR DESCRIPTION
The previous `Listen()` function was more a `ListenAndServe()`
function and it triggers a race condition when calling `Close()`: call
it too early and you get a panic because the listener is not ready.
Just checking for `nil` in `Close()` would trigger another race
condition where the listener would not be stopped despite calling
`Close()` (because it was called too early).