### PR TITLE
Rework the IP datatype to be a value by default and change prefix to contain an IP and not a pointer

### DIFF
--- a/net/ip_test.go
+++ b/net/ip_test.go
@@ -111,7 +111,7 @@ func TestIPFromProtoIP(t *testing.T) {
 	tests := []struct {
 		name     string
 		proto    api.IP
-		expected *IP
+		expected IP
 	}{
 		{
 			name: "Test IPv4",
@@ -120,7 +120,7 @@ func TestIPFromProtoIP(t *testing.T) {
 				Higher:  0,
 				Version: api.IP_IPv4,
 			},
-			expected: &IP{
+			expected: IP{
 				lower:    100,
 				higher:   0,
 				isLegacy: true,
@@ -133,7 +133,7 @@ func TestIPFromProtoIP(t *testing.T) {
 				Higher:  200,
 				Version: api.IP_IPv6,
 			},
-			expected: &IP{
+			expected: IP{
 				lower:    100,
 				higher:   200,
 				isLegacy: false,
@@ -593,23 +593,23 @@ func TestSizeBytes(t *testing.T) {
 func TestNext(t *testing.T) {
 	tests := []struct {
 		name     string
-		input    *IP
-		expected *IP
+		input    IP
+		expected IP
 	}{
 		{
 			name:     "Test #1",
-			input:    IPv4FromOctets(10, 0, 0, 1).Dedup(),
-			expected: IPv4FromOctets(10, 0, 0, 2).Dedup(),
+			input:    IPv4FromOctets(10, 0, 0, 1),
+			expected: IPv4FromOctets(10, 0, 0, 2),
 		},
 		{
 			name:     "Test #2",
-			input:    IPv6FromBlocks(10, 20, 30, 40, 50, 60, 70, 80).Dedup(),
-			expected: IPv6FromBlocks(10, 20, 30, 40, 50, 60, 70, 81).Dedup(),
+			input:    IPv6FromBlocks(10, 20, 30, 40, 50, 60, 70, 80),
+			expected: IPv6FromBlocks(10, 20, 30, 40, 50, 60, 70, 81),
 		},
 		{
 			name:     "Test #3",
-			input:    IPv6FromBlocks(10, 20, 30, 40, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF).Dedup(),
-			expected: IPv6FromBlocks(10, 20, 30, 41, 0, 0, 0, 0).Dedup(),
+			input:    IPv6FromBlocks(10, 20, 30, 40, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF),
+			expected: IPv6FromBlocks(10, 20, 30, 41, 0, 0, 0, 0),
 		},
 	}
 
@@ -621,51 +621,51 @@ func TestNext(t *testing.T) {
 func TestMaskLastNBits(t *testing.T) {
 	tests := []struct {
 		name     string
-		input    *IP
+		input    IP
 		maskBits uint8
-		expected *IP
+		expected IP
 	}{
 		{
 			name:     "Test #1",
-			input:    IPv4FromOctets(10, 1, 1, 1).Dedup(),
+			input:    IPv4FromOctets(10, 1, 1, 1),
 			maskBits: 8,
-			expected: IPv4FromOctets(10, 1, 1, 0).Dedup(),
+			expected: IPv4FromOctets(10, 1, 1, 0),
 		},
 		{
 			name:     "Test #2",
-			input:    IPv4FromOctets(185, 65, 241, 123).Dedup(),
+			input:    IPv4FromOctets(185, 65, 241, 123),
 			maskBits: 9,
-			expected: IPv4FromOctets(185, 65, 240, 0).Dedup(),
+			expected: IPv4FromOctets(185, 65, 240, 0),
 		},
 		{
 			name:     "Test #3",
-			input:    IPv4FromOctets(185, 65, 241, 123).Dedup(),
+			input:    IPv4FromOctets(185, 65, 241, 123),
 			maskBits: 32,
-			expected: IPv4FromOctets(0, 0, 0, 0).Dedup(),
+			expected: IPv4FromOctets(0, 0, 0, 0),
 		},
 		{
 			name:     "Test #4",
-			input:    IPv6FromBlocks(0x2001, 0xaaaa, 0x1234, 0x2222, 0x1111, 0x3333, 0xbbbb, 0xacab).Dedup(),
+			input:    IPv6FromBlocks(0x2001, 0xaaaa, 0x1234, 0x2222, 0x1111, 0x3333, 0xbbbb, 0xacab),
 			maskBits: 16,
-			expected: IPv6FromBlocks(0x2001, 0xaaaa, 0x1234, 0x2222, 0x1111, 0x3333, 0xbbbb, 0x0000).Dedup(),
+			expected: IPv6FromBlocks(0x2001, 0xaaaa, 0x1234, 0x2222, 0x1111, 0x3333, 0xbbbb, 0x0000),
 		},
 		{
 			name:     "Test #5",
-			input:    IPv6FromBlocks(0x2001, 0xaaaa, 0x1234, 0x2222, 0x1111, 0x3333, 0xbbbb, 0xacab).Dedup(),
+			input:    IPv6FromBlocks(0x2001, 0xaaaa, 0x1234, 0x2222, 0x1111, 0x3333, 0xbbbb, 0xacab),
 			maskBits: 64,
-			expected: IPv6FromBlocks(0x2001, 0xaaaa, 0x1234, 0x2222, 0x0000, 0x0000, 0x0000, 0x0000).Dedup(),
+			expected: IPv6FromBlocks(0x2001, 0xaaaa, 0x1234, 0x2222, 0x0000, 0x0000, 0x0000, 0x0000),
 		},
 		{
 			name:     "Test #6",
-			input:    IPv6FromBlocks(0x2001, 0xaaaa, 0x1234, 0x2222, 0x1111, 0x3333, 0xbbbb, 0xacab).Dedup(),
+			input:    IPv6FromBlocks(0x2001, 0xaaaa, 0x1234, 0x2222, 0x1111, 0x3333, 0xbbbb, 0xacab),
 			maskBits: 80,
-			expected: IPv6FromBlocks(0x2001, 0xaaaa, 0x1234, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000).Dedup(),
+			expected: IPv6FromBlocks(0x2001, 0xaaaa, 0x1234, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000),
 		},
 		{
 			name:     "Test #7",
-			input:    IPv6FromBlocks(0x2001, 0xaaaa, 0x1234, 0x2222, 0x1111, 0x3333, 0xbbbb, 0xacab).Dedup(),
+			input:    IPv6FromBlocks(0x2001, 0xaaaa, 0x1234, 0x2222, 0x1111, 0x3333, 0xbbbb, 0xacab),
 			maskBits: 128,
-			expected: IPv6FromBlocks(0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000).Dedup(),
+			expected: IPv6FromBlocks(0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000),
 		},
 	}
 

--- a/net/prefix.go
+++ b/net/prefix.go
@@ -12,7 +12,7 @@ import (
 
 // Prefix represents an IPv4 prefix
 type Prefix struct {
-	addr   *IP
+	addr   IP
 	pfxlen uint8
 }
 
@@ -53,7 +53,7 @@ func PrefixFromString(s string) (*Prefix, error) {
 	}
 
 	return &Prefix{
-		addr:   ip.Dedup(),
+		addr:   ip,
 		pfxlen: uint8(l),
 	}, nil
 }
@@ -69,7 +69,7 @@ func (p Prefix) ToProto() *api.Prefix {
 // NewPfx creates a new Prefix
 func NewPfx(addr IP, pfxlen uint8) Prefix {
 	return Prefix{
-		addr:   addr.Dedup(),
+		addr:   addr,
 		pfxlen: pfxlen,
 	}
 }
@@ -80,7 +80,7 @@ func NewPfxFromIPNet(ipNet *gonet.IPNet) *Prefix {
 	ip, _ := IPFromBytes(ipNet.IP)
 
 	return &Prefix{
-		addr:   ip.Dedup(),
+		addr:   ip,
 		pfxlen: uint8(ones),
 	}
 }
@@ -110,7 +110,7 @@ func StrToAddr(x string) (uint32, error) {
 }
 
 // Addr returns the address of the prefix
-func (pfx *Prefix) Addr() *IP {
+func (pfx *Prefix) Addr() IP {
 	return pfx.addr
 }
 
@@ -121,7 +121,7 @@ func (pfx *Prefix) Pfxlen() uint8 {
 
 // String returns a string representation of pfx
 func (pfx *Prefix) String() string {
-	return fmt.Sprintf("%s/%d", pfx.addr, pfx.pfxlen)
+	return fmt.Sprintf("%s/%d", pfx.addr.String(), pfx.pfxlen)
 }
 
 // GetIPNet returns the gonet.IP object for a Prefix object
@@ -197,7 +197,7 @@ func (pfx *Prefix) supernetIPv4(x *Prefix) Prefix {
 	}
 
 	return Prefix{
-		addr:   IPv4(a << (32 - maxPfxLen)).Dedup(),
+		addr:   IPv4(a << (32 - maxPfxLen)),
 		pfxlen: maxPfxLen,
 	}
 }
@@ -266,7 +266,7 @@ func checkLastNBitsUint64(x uint64, n uint8) bool {
 }
 
 // BaseAddr gets the base address of the prefix
-func (p *Prefix) BaseAddr() *IP {
+func (p *Prefix) BaseAddr() IP {
 	if p.addr.isLegacy {
 		return p.baseAddr4()
 	}
@@ -274,7 +274,7 @@ func (p *Prefix) BaseAddr() *IP {
 	return p.baseAddr6()
 }
 
-func (p *Prefix) baseAddr4() *IP {
+func (p *Prefix) baseAddr4() IP {
 	addr := p.addr.copy()
 
 	addr.lower = addr.lower >> (32 - p.pfxlen)
@@ -283,7 +283,7 @@ func (p *Prefix) baseAddr4() *IP {
 	return addr
 }
 
-func (p *Prefix) baseAddr6() *IP {
+func (p *Prefix) baseAddr6() IP {
 	addr := p.addr.copy()
 
 	if p.pfxlen <= 64 {

--- a/net/prefix_cache.go
+++ b/net/prefix_cache.go
@@ -28,7 +28,6 @@ func newPfxCache() *pfxCache {
 }
 
 func (pfxc *pfxCache) get(pfx Prefix) *Prefix {
-	pfx.addr = pfx.addr.Dedup()
 	pfxc.cacheMu.Lock()
 
 	if p, exists := pfxc.cache[pfx]; exists {

--- a/net/prefix_cache_test.go
+++ b/net/prefix_cache_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestPrefixCache(t *testing.T) {
 	a := &Prefix{
-		addr: &IP{
+		addr: IP{
 			higher:   100,
 			lower:    200,
 			isLegacy: false,
@@ -16,16 +16,13 @@ func TestPrefixCache(t *testing.T) {
 		pfxlen: 64,
 	}
 	b := &Prefix{
-		addr: &IP{
+		addr: IP{
 			higher:   100,
 			lower:    200,
 			isLegacy: false,
 		},
 		pfxlen: 64,
 	}
-
-	a.addr = a.addr.Dedup()
-	b.addr = b.addr.Dedup()
 
 	x := a.Dedup()
 	y := b.Dedup()

--- a/net/prefix_test.go
+++ b/net/prefix_test.go
@@ -66,7 +66,7 @@ func TestPrefixToProto(t *testing.T) {
 		{
 			name: "IPv4",
 			pfx: Prefix{
-				addr: &IP{
+				addr: IP{
 					lower:    200,
 					isLegacy: true,
 				},
@@ -83,7 +83,7 @@ func TestPrefixToProto(t *testing.T) {
 		{
 			name: "IPv6",
 			pfx: Prefix{
-				addr: &IP{
+				addr: IP{
 					higher:   100,
 					lower:    200,
 					isLegacy: false,
@@ -124,7 +124,7 @@ func TestNewPrefixFromProtoPrefix(t *testing.T) {
 				Pfxlen: 24,
 			},
 			expected: Prefix{
-				addr: &IP{
+				addr: IP{
 					higher:   0,
 					lower:    2000,
 					isLegacy: true,
@@ -143,7 +143,7 @@ func TestNewPrefixFromProtoPrefix(t *testing.T) {
 				Pfxlen: 64,
 			},
 			expected: Prefix{
-				addr: &IP{
+				addr: IP{
 					higher:   1000,
 					lower:    2000,
 					isLegacy: false,
@@ -161,7 +161,7 @@ func TestNewPrefixFromProtoPrefix(t *testing.T) {
 
 func TestNewPfx(t *testing.T) {
 	p := NewPfx(IPv4(123), 11)
-	if *p.addr != IPv4(123) || p.pfxlen != 11 {
+	if p.addr != IPv4(123) || p.pfxlen != 11 {
 		t.Errorf("NewPfx() failed: Unexpected values")
 	}
 }
@@ -181,7 +181,7 @@ func TestAddr(t *testing.T) {
 
 	for _, test := range tests {
 		res := test.pfx.Addr()
-		assert.Equal(t, *res, test.expected, "Unexpected result for test %s", test.name)
+		assert.Equal(t, res, test.expected, "Unexpected result for test %s", test.name)
 	}
 }
 
@@ -214,75 +214,75 @@ func TestGetSupernet(t *testing.T) {
 		{
 			name: "Supernet of 10.0.0.0 and 11.100.123.0 -> 10.0.0.0/7",
 			a: &Prefix{
-				addr:   IPv4FromOctets(10, 0, 0, 0).Ptr(),
+				addr:   IPv4FromOctets(10, 0, 0, 0),
 				pfxlen: 8,
 			},
 			b: &Prefix{
-				addr:   IPv4FromOctets(11, 100, 123, 0).Ptr(),
+				addr:   IPv4FromOctets(11, 100, 123, 0),
 				pfxlen: 24,
 			},
 			expected: &Prefix{
-				addr:   IPv4FromOctets(10, 0, 0, 0).Dedup(),
+				addr:   IPv4FromOctets(10, 0, 0, 0),
 				pfxlen: 7,
 			},
 		},
 		{
 			name: "Supernet of 10.0.0.0 and 192.168.0.0 -> 0.0.0.0/0",
 			a: &Prefix{
-				addr:   IPv4FromOctets(10, 0, 0, 0).Ptr(),
+				addr:   IPv4FromOctets(10, 0, 0, 0),
 				pfxlen: 8,
 			},
 			b: &Prefix{
-				addr:   IPv4FromOctets(192, 168, 0, 0).Ptr(),
+				addr:   IPv4FromOctets(192, 168, 0, 0),
 				pfxlen: 24,
 			},
 			expected: &Prefix{
-				addr:   IPv4(0).Dedup(),
+				addr:   IPv4(0),
 				pfxlen: 0,
 			},
 		},
 		{
 			name: "Supernet of 2001:678:1e0:100:23::/64 and 2001:678:1e0:1ff::/64 -> 2001:678:1e0:100::/56",
 			a: &Prefix{
-				addr:   IPv6FromBlocks(0x2001, 0x678, 0x1e0, 0x100, 0x23, 0, 0, 0).Ptr(),
+				addr:   IPv6FromBlocks(0x2001, 0x678, 0x1e0, 0x100, 0x23, 0, 0, 0),
 				pfxlen: 64,
 			},
 			b: &Prefix{
-				addr:   IPv6FromBlocks(0x2001, 0x678, 0x1e0, 0x1ff, 0, 0, 0, 0).Ptr(),
+				addr:   IPv6FromBlocks(0x2001, 0x678, 0x1e0, 0x1ff, 0, 0, 0, 0),
 				pfxlen: 64,
 			},
 			expected: &Prefix{
-				addr:   IPv6FromBlocks(0x2001, 0x678, 0x1e0, 0x100, 0, 0, 0, 0).Dedup(),
+				addr:   IPv6FromBlocks(0x2001, 0x678, 0x1e0, 0x100, 0, 0, 0, 0),
 				pfxlen: 56,
 			},
 		},
 		{
 			name: "Supernet of 2001:678:1e0::/128 and 2001:678:1e0::1/128 -> 2001:678:1e0:100::/127",
 			a: &Prefix{
-				addr:   IPv6FromBlocks(0x2001, 0x678, 0x1e0, 0, 0, 0, 0, 0).Ptr(),
+				addr:   IPv6FromBlocks(0x2001, 0x678, 0x1e0, 0, 0, 0, 0, 0),
 				pfxlen: 128,
 			},
 			b: &Prefix{
-				addr:   IPv6FromBlocks(0x2001, 0x678, 0x1e0, 0, 0, 0, 0, 1).Ptr(),
+				addr:   IPv6FromBlocks(0x2001, 0x678, 0x1e0, 0, 0, 0, 0, 1),
 				pfxlen: 128,
 			},
 			expected: &Prefix{
-				addr:   IPv6FromBlocks(0x2001, 0x678, 0x1e0, 0, 0, 0, 0, 0).Dedup(),
+				addr:   IPv6FromBlocks(0x2001, 0x678, 0x1e0, 0, 0, 0, 0, 0),
 				pfxlen: 127,
 			},
 		},
 		{
 			name: "Supernet of all ones and all zeros -> ::/0",
 			a: &Prefix{
-				addr:   IPv6FromBlocks(0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF).Ptr(),
+				addr:   IPv6FromBlocks(0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF),
 				pfxlen: 128,
 			},
 			b: &Prefix{
-				addr:   IPv6(0, 0).Ptr(),
+				addr:   IPv6(0, 0),
 				pfxlen: 128,
 			},
 			expected: &Prefix{
-				addr:   IPv6FromBlocks(0, 0, 0, 0, 0, 0, 0, 0).Dedup(),
+				addr:   IPv6FromBlocks(0, 0, 0, 0, 0, 0, 0, 0),
 				pfxlen: 0,
 			},
 		},
@@ -306,132 +306,132 @@ func TestContains(t *testing.T) {
 	}{
 		{
 			a: &Prefix{
-				addr:   IPv4(0).Ptr(),
+				addr:   IPv4(0),
 				pfxlen: 0,
 			},
 			b: &Prefix{
-				addr:   IPv4(100).Ptr(),
+				addr:   IPv4(100),
 				pfxlen: 24,
 			},
 			expected: true,
 		},
 		{
 			a: &Prefix{
-				addr:   IPv4(100).Ptr(),
+				addr:   IPv4(100),
 				pfxlen: 24,
 			},
 			b: &Prefix{
-				addr:   IPv4(0).Ptr(),
+				addr:   IPv4(0),
 				pfxlen: 0,
 			},
 			expected: false,
 		},
 		{
 			a: &Prefix{
-				addr:   IPv4(167772160).Ptr(),
+				addr:   IPv4(167772160),
 				pfxlen: 8,
 			},
 			b: &Prefix{
-				addr:   IPv4(167772160).Ptr(),
+				addr:   IPv4(167772160),
 				pfxlen: 9,
 			},
 			expected: true,
 		},
 		{
 			a: &Prefix{
-				addr:   IPv4(167772160).Ptr(),
+				addr:   IPv4(167772160),
 				pfxlen: 8,
 			},
 			b: &Prefix{
-				addr:   IPv4(174391040).Ptr(),
+				addr:   IPv4(174391040),
 				pfxlen: 24,
 			},
 			expected: true,
 		},
 		{
 			a: &Prefix{
-				addr:   IPv4(167772160).Ptr(),
+				addr:   IPv4(167772160),
 				pfxlen: 8,
 			},
 			b: &Prefix{
-				addr:   IPv4(184549377).Ptr(),
+				addr:   IPv4(184549377),
 				pfxlen: 24,
 			},
 			expected: false,
 		},
 		{
 			a: &Prefix{
-				addr:   IPv4(167772160).Ptr(),
+				addr:   IPv4(167772160),
 				pfxlen: 8,
 			},
 			b: &Prefix{
-				addr:   IPv4(191134464).Ptr(),
+				addr:   IPv4(191134464),
 				pfxlen: 24,
 			},
 			expected: false,
 		},
 		{
 			a: &Prefix{
-				addr:   IPv4FromOctets(169, 0, 0, 0).Ptr(),
+				addr:   IPv4FromOctets(169, 0, 0, 0),
 				pfxlen: 25,
 			},
 			b: &Prefix{
-				addr:   IPv4FromOctets(169, 1, 1, 0).Ptr(),
+				addr:   IPv4FromOctets(169, 1, 1, 0),
 				pfxlen: 26,
 			},
 			expected: false,
 		},
 		{
 			a: &Prefix{
-				addr:   IPv6FromBlocks(0x2001, 0x678, 0x1e0, 0, 0, 0, 0, 0).Ptr(),
+				addr:   IPv6FromBlocks(0x2001, 0x678, 0x1e0, 0, 0, 0, 0, 0),
 				pfxlen: 48,
 			},
 			expected: true,
 			b: &Prefix{
-				addr:   IPv6FromBlocks(0x2001, 0x678, 0x1e0, 0x100, 0, 0, 0, 0).Ptr(),
+				addr:   IPv6FromBlocks(0x2001, 0x678, 0x1e0, 0x100, 0, 0, 0, 0),
 				pfxlen: 56,
 			},
 		},
 		{
 			a: &Prefix{
-				addr:   IPv6FromBlocks(0x2001, 0x678, 0x1e0, 0x200, 0, 0, 0, 0).Ptr(),
+				addr:   IPv6FromBlocks(0x2001, 0x678, 0x1e0, 0x200, 0, 0, 0, 0),
 				pfxlen: 56,
 			},
 			b: &Prefix{
-				addr:   IPv6FromBlocks(0x2001, 0x678, 0x1e0, 0x100, 0, 0, 0, 0).Ptr(),
+				addr:   IPv6FromBlocks(0x2001, 0x678, 0x1e0, 0x100, 0, 0, 0, 0),
 				pfxlen: 64,
 			},
 			expected: false,
 		},
 		{
 			a: &Prefix{
-				addr:   IPv6FromBlocks(0x2001, 0x678, 0x1e0, 0x200, 0, 0, 0, 0).Ptr(),
+				addr:   IPv6FromBlocks(0x2001, 0x678, 0x1e0, 0x200, 0, 0, 0, 0),
 				pfxlen: 65,
 			},
 			b: &Prefix{
-				addr:   IPv6FromBlocks(0x2001, 0x678, 0x1e0, 0x100, 0, 0, 0, 0).Ptr(),
+				addr:   IPv6FromBlocks(0x2001, 0x678, 0x1e0, 0x100, 0, 0, 0, 0),
 				pfxlen: 64,
 			},
 			expected: false,
 		},
 		{
 			a: &Prefix{
-				addr:   IPv6FromBlocks(0x2001, 0x678, 0x1e0, 0x100, 100, 0, 0, 0).Ptr(),
+				addr:   IPv6FromBlocks(0x2001, 0x678, 0x1e0, 0x100, 100, 0, 0, 0),
 				pfxlen: 72,
 			},
 			b: &Prefix{
-				addr:   IPv6FromBlocks(0x2001, 0x678, 0x1e0, 0x100, 100, 0, 0, 1).Ptr(),
+				addr:   IPv6FromBlocks(0x2001, 0x678, 0x1e0, 0x100, 100, 0, 0, 1),
 				pfxlen: 127,
 			},
 			expected: true,
 		},
 		{
 			a: &Prefix{
-				addr:   IPv6FromBlocks(0x2001, 0x678, 0x1e0, 0x100, 100, 0, 0, 0).Ptr(),
+				addr:   IPv6FromBlocks(0x2001, 0x678, 0x1e0, 0x100, 100, 0, 0, 0),
 				pfxlen: 126,
 			},
 			b: &Prefix{
-				addr:   IPv6FromBlocks(0x2001, 0x678, 0x1e0, 0x100, 100, 0, 100, 1).Ptr(),
+				addr:   IPv6FromBlocks(0x2001, 0x678, 0x1e0, 0x100, 100, 0, 100, 1),
 				pfxlen: 127,
 			},
 			expected: false,
@@ -662,32 +662,32 @@ func TestBaseAddr(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    *Prefix
-		expected *IP
+		expected IP
 	}{
 		{
 			name:     "Test #1",
-			input:    NewPfx(IPv4FromOctets(10, 1, 1, 0), 23).Dedup(),
-			expected: IPv4FromOctets(10, 1, 0, 0).Dedup(),
+			input:    NewPfx(IPv4FromOctets(10, 1, 1, 0), 23).Ptr(),
+			expected: IPv4FromOctets(10, 1, 0, 0),
 		},
 		{
 			name:     "Test #2",
-			input:    NewPfx(IPv4FromOctets(10, 1, 1, 2), 24).Dedup(),
-			expected: IPv4FromOctets(10, 1, 1, 0).Dedup(),
+			input:    NewPfx(IPv4FromOctets(10, 1, 1, 2), 24).Ptr(),
+			expected: IPv4FromOctets(10, 1, 1, 0),
 		},
 		{
 			name:     "Test #3",
-			input:    NewPfx(IPv6FromBlocks(10, 10, 20, 20, 1, 0, 0, 1), 64).Dedup(),
-			expected: IPv6FromBlocks(10, 10, 20, 20, 0, 0, 0, 0).Dedup(),
+			input:    NewPfx(IPv6FromBlocks(10, 10, 20, 20, 1, 0, 0, 1), 64).Ptr(),
+			expected: IPv6FromBlocks(10, 10, 20, 20, 0, 0, 0, 0),
 		},
 		{
 			name:     "Test #4",
-			input:    NewPfx(IPv6FromBlocks(10, 10, 20, 20, 1, 0, 0, 1), 48).Dedup(),
-			expected: IPv6FromBlocks(10, 10, 20, 0, 0, 0, 0, 0).Dedup(),
+			input:    NewPfx(IPv6FromBlocks(10, 10, 20, 20, 1, 0, 0, 1), 48).Ptr(),
+			expected: IPv6FromBlocks(10, 10, 20, 0, 0, 0, 0, 0),
 		},
 		{
 			name:     "Test #5",
-			input:    NewPfx(IPv6FromBlocks(10, 10, 20, 20, 1, 0, 5, 1), 126).Dedup(),
-			expected: IPv6FromBlocks(10, 10, 20, 20, 1, 0, 5, 0).Dedup(),
+			input:    NewPfx(IPv6FromBlocks(10, 10, 20, 20, 1, 0, 5, 1), 126).Ptr(),
+			expected: IPv6FromBlocks(10, 10, 20, 20, 1, 0, 5, 0),
 		},
 	}
 

--- a/protocols/bgp/server/bgp_api.go
+++ b/protocols/bgp/server/bgp_api.go
@@ -29,7 +29,7 @@ func (s *BGPAPIServer) ListSessions(ctx context.Context, in *api.ListSessionsReq
 
 // DumpRIBIn dumps the RIB in of a peer for a given AFI/SAFI
 func (s *BGPAPIServer) DumpRIBIn(in *api.DumpRIBRequest, stream api.BgpService_DumpRIBInServer) error {
-	r := s.srv.GetRIBIn(bnet.IPFromProtoIP(in.Peer), uint16(in.Afi), uint8(in.Safi))
+	r := s.srv.GetRIBIn(bnet.IPFromProtoIP(in.Peer).Ptr(), uint16(in.Afi), uint8(in.Safi))
 	if r == nil {
 		return fmt.Errorf("unable to get AdjRIBIn")
 	}
@@ -47,7 +47,7 @@ func (s *BGPAPIServer) DumpRIBIn(in *api.DumpRIBRequest, stream api.BgpService_D
 
 // DumpRIBOut dumps the RIB out of a peer for a given AFI/SAFI
 func (s *BGPAPIServer) DumpRIBOut(in *api.DumpRIBRequest, stream api.BgpService_DumpRIBOutServer) error {
-	r := s.srv.GetRIBOut(bnet.IPFromProtoIP(in.Peer), uint16(in.Afi), uint8(in.Safi))
+	r := s.srv.GetRIBOut(bnet.IPFromProtoIP(in.Peer).Ptr(), uint16(in.Afi), uint8(in.Safi))
 	if r == nil {
 		return fmt.Errorf("unable to get AdjRIBOut")
 	}

--- a/route/bgp_path.go
+++ b/route/bgp_path.go
@@ -124,14 +124,14 @@ func (b *BGPPath) ToProto() *api.BGPPath {
 func BGPPathFromProtoBGPPath(pb *api.BGPPath, dedup bool) *BGPPath {
 	p := &BGPPath{
 		BGPPathA: &BGPPathA{
-			NextHop:        bnet.IPFromProtoIP(pb.NextHop),
+			NextHop:        bnet.IPFromProtoIP(pb.NextHop).Ptr(),
 			LocalPref:      pb.LocalPref,
 			OriginatorID:   pb.OriginatorId,
 			Origin:         uint8(pb.Origin),
 			MED:            pb.Med,
 			EBGP:           pb.Ebgp,
 			BGPIdentifier:  pb.BgpIdentifier,
-			Source:         bnet.IPFromProtoIP(pb.Source),
+			Source:         bnet.IPFromProtoIP(pb.Source).Ptr(),
 			OnlyToCustomer: pb.OnlyToCustomer,
 		},
 		PathIdentifier: pb.PathIdentifier,

--- a/route/route.go
+++ b/route/route.go
@@ -88,7 +88,7 @@ func (r *Route) Prefix() *net.Prefix {
 
 // Addr gets a routes address
 func (r *Route) Addr() *net.IP {
-	return r.pfx.Addr()
+	return r.pfx.Addr().Ptr()
 }
 
 // Pfxlen gets a routes prefix length

--- a/route/static.go
+++ b/route/static.go
@@ -61,6 +61,6 @@ func (s *StaticPath) ToProto() *api.StaticPath {
 // StaticPathFromProtoStaticPath converts a proto StaticPath to StaticPath
 func StaticPathFromProtoStaticPath(pb *api.StaticPath, dedup bool) *StaticPath {
 	return &StaticPath{
-		NextHop: bnet.IPFromProtoIP(pb.NextHop),
+		NextHop: bnet.IPFromProtoIP(pb.NextHop).Ptr(),
 	}
 }


### PR DESCRIPTION
We used to try do deduplicate IP addresses and prefixes as good as possible while doing so in a very controlled way.
This change rolls back the implicit deduplications happening in Prefix objects. I think in generals that we should handle IP addresses as plain objects whenever possible and only use pointers when we actually need the information to be deduplicated for memory efficiency reason. And that is actually only necessary in the routing tables. Path attributes are themselves deduplicated and to keep it simple we should not deduplicate the pieces that make up the path attributes.