### PR TITLE
Remove redundant bio_bgp_up metric

### DIFF
--- a/protocols/bgp/metrics/bgp_peer_metrics.go
+++ b/protocols/bgp/metrics/bgp_peer_metrics.go
@@ -36,9 +36,6 @@ type BGPPeerMetrics struct {
 	// State of the BGP session (Down = 0, Idle = 1, Connect = 2, Active = 3, OpenSent = 4, OpenConfirm = 5, Established = 6)
 	State uint8
 
-	// Up returns if the session is established
-	Up bool
-
 	// UpdatesReceived is the number of update messages received on this session
 	UpdatesReceived uint64
 

--- a/protocols/bgp/server/metrics_service.go
+++ b/protocols/bgp/server/metrics_service.go
@@ -41,9 +41,8 @@ func metricsForPeer(peer *peer) *metrics.BGPPeerMetrics {
 
 	fsm := fsms[0]
 	m.State = statusFromFSM(fsm)
-	m.Up = m.State == metrics.StateEstablished
 
-	if m.Up {
+	if m.State == metrics.StateEstablished {
 		m.Since = fsm.establishedTime
 	}
 

--- a/protocols/bgp/server/metrics_service_test.go
+++ b/protocols/bgp/server/metrics_service_test.go
@@ -58,7 +58,6 @@ func TestMetrics(t *testing.T) {
 						UpdatesReceived: 3,
 						UpdatesSent:     4,
 						VRF:             "inet.0",
-						Up:              true,
 						State:           metrics.StateEstablished,
 						Since:           establishedTime,
 						AddressFamilies: []*metrics.BGPAddressFamilyMetrics{


### PR DESCRIPTION
The metrics »bio_bgp_up« is exposing the exact same value as the metric
»bio_bgp_state« having the value 6 so it adds redundant data to Prometheus
which becomes a concern at scale.