### PR TITLE
Reflect Golang net.IP changes

### DIFF
--- a/net/ip.go
+++ b/net/ip.go
@@ -112,8 +112,9 @@ func IPv4FromBytes(b []byte) IP {
 
 // IPFromBytes returns an IP address for a byte slice
 func IPFromBytes(b []byte) (IP, error) {
-	if len(b) == 4 {
-		return IPv4FromOctets(b[0], b[1], b[2], b[3]), nil
+	ip4 := net.IP(b).To4()
+	if ip4 != nil {
+		return IPv4FromOctets(ip4[0], ip4[1], ip4[2], ip4[3]), nil
 	}
 
 	if len(b) == 16 {

--- a/net/ip_test.go
+++ b/net/ip_test.go
@@ -374,11 +374,29 @@ func TestIPFromBytes(t *testing.T) {
 		wantFail bool
 	}{
 		{
-			name:  "IPV4: 172.217.16.195",
+			name:  "IPv4, 4 bytes: 172.217.16.195",
 			bytes: []byte{172, 217, 16, 195},
 			expected: IP{
 				higher:   0,
 				lower:    2899906755,
+				isLegacy: true,
+			},
+		},
+		{
+			name:  "IPv4, 16 bytes: 172.217.16.195",
+			bytes: []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 172, 217, 16, 195},
+			expected: IP{
+				higher:   0,
+				lower:    2899906755,
+				isLegacy: true,
+			},
+		},
+		{
+			name:  "IPv4, from Go net.IPv4()",
+			bytes: net.IPv4(224, 0, 0, 1),
+			expected: IP{
+				higher:   0,
+				lower:    3758096385,
 				isLegacy: true,
 			},
 		},


### PR DESCRIPTION
  It looks like Golang changed the behavior of the net.IP type with the latest
  redesign, so that the address family cannot be determined anymore by looking
  at the length of the underlying byte slice.  Adding two more tests to notice
  any regressions early in the future.