### PR TITLE
Allow configuring if pre-/policy UPDATEs should  be ignored

### DIFF
--- a/cmd/ris/main.go
+++ b/cmd/ris/main.go
@@ -50,9 +50,11 @@ func main() {
 	}
 
 	b := server.NewServer(server.BMPServerConfig{
-		KeepalivePeriod: time.Duration(*tcpKeepaliveInterval) * time.Second,
-		AcceptAny:       *allowAny,
-		IgnorePeerASNs:  cfg.IgnorePeerASNs,
+		KeepalivePeriod:  time.Duration(*tcpKeepaliveInterval) * time.Second,
+		AcceptAny:        *allowAny,
+		IgnorePeerASNs:   cfg.IgnorePeerASNs,
+		IgnorePrePolicy:  true,
+		IgnorePostPolicy: false,
 	})
 
 	if *bmpListenAddr != "" {

--- a/protocols/bgp/server/bmp_server_test.go
+++ b/protocols/bgp/server/bmp_server_test.go
@@ -14,7 +14,11 @@ func TestBMPServer(t *testing.T) {
 		KeepalivePeriod: time.Second,
 	})
 
-	rtr := newRouter(net.IP{10, 0, 255, 1}, 30119, false, &adjRIBInFactory{}, []uint32{13335})
+	rCfg := RouterConfig{
+		Passive:        false,
+		IgnorePeerASNs: []uint32{13335},
+	}
+	rtr := newRouter(net.IP{10, 0, 255, 1}, 30119, &adjRIBInFactory{}, rCfg)
 	_, pipe := net.Pipe()
 	rtr.con = pipe
 	srv.routers[rtr.address.String()] = rtr


### PR DESCRIPTION
  Until recently bio BMP accepted all UPDATEs regardless of pre of post
  policy.  Commit 634c76c2540675e185dd6d044b49d55930fe2dc7 changed this
  with the RIS use case in mind, but there are other use cases in which
  we need to see pre-policy UPDATEs instead of even as well.  This commit
  makes the behavior configurable, changing the default back to accepting
  pre as well as post policy UPDATEs.