### PR TITLE
fix: example bgp with v6 and cleanup

### DIFF
--- a/examples/bgp/ipv4.go
+++ b/examples/bgp/ipv4.go
@@ -1,70 +1,58 @@
-//go:build ipv6
-// +build ipv6
-
 package main
 
 import (
-	"net"
 	"time"
 
-	"github.com/bio-routing/bio-rd/config"
 	bnet "github.com/bio-routing/bio-rd/net"
 	"github.com/bio-routing/bio-rd/protocols/bgp/server"
 	"github.com/bio-routing/bio-rd/routingtable"
 	"github.com/bio-routing/bio-rd/routingtable/filter"
 	"github.com/bio-routing/bio-rd/routingtable/vrf"
-	"github.com/sirupsen/logrus"
 )
 
-func startServer(b server.BGPServer, v *vrf.VRF) {
-	err := b.Start(&config.Global{
-		Listen: true,
-		LocalAddressList: []net.IP{
-			{0x20, 0x01, 0x6, 0x78, 0x1, 0xe0, 0, 0, 0, 0, 0, 0, 0, 0, 0xca, 0xfe},
-		},
-	})
-	if err != nil {
-		logrus.Fatalf("Unable to start BGP server: %v", err)
-	}
-
+func addPeersIPv4(b server.BGPServer, v *vrf.VRF) {
 	b.AddPeer(server.PeerConfig{
 		AdminEnabled:      true,
 		LocalAS:           65200,
-		PeerAS:            202739,
-		PeerAddress:       bnet.IPv6FromBlocks(0x2001, 0x678, 0x1e0, 0, 0, 0, 0, 1),
-		LocalAddress:      bnet.IPv6FromBlocks(0x2001, 0x678, 0x1e0, 0, 0, 0, 0, 0xcafe),
+		PeerAS:            65300,
+		PeerAddress:       bnet.IPv4FromOctets(172, 17, 0, 3).Ptr(),
+		LocalAddress:      bnet.IPv4FromOctets(169, 254, 200, 0).Ptr(),
 		ReconnectInterval: time.Second * 15,
 		HoldTime:          time.Second * 90,
 		KeepAlive:         time.Second * 30,
 		Passive:           true,
 		RouterID:          b.RouterID(),
-		IPv6: &server.AddressFamilyConfig{
+		IPv4: &server.AddressFamilyConfig{
 			ImportFilterChain: filter.NewAcceptAllFilterChain(),
-			ExportFilterChain: filter.NewDrainFilterChain(),
-			AddPathSend: routingtable.ClientOptions{
-				BestOnly: true,
-			},
-		},
-		VRF: v,
-	})
-
-	b.AddPeer(server.PeerConfig{
-		AdminEnabled:      true,
-		LocalAS:           65200,
-		PeerAS:            65400,
-		PeerAddress:       bnet.IPv6FromBlocks(0x2001, 0x678, 0x1e0, 0xcafe, 0, 0, 0, 5),
-		LocalAddress:      bnet.IPv6FromBlocks(0x2001, 0x678, 0x1e0, 0, 0, 0, 0, 0xcafe),
-		ReconnectInterval: time.Second * 15,
-		HoldTime:          time.Second * 90,
-		KeepAlive:         time.Second * 30,
-		Passive:           true,
-		RouterID:          b.RouterID(),
-		IPv6: &server.AddressFamilyConfig{
-			ImportFilterChain: filter.NewDrainFilterChain(),
 			ExportFilterChain: filter.NewAcceptAllFilterChain(),
 			AddPathSend: routingtable.ClientOptions{
-				BestOnly: true,
+				MaxPaths: 10,
 			},
 		},
+		RouteServerClient: true,
+		VRF:               v,
+	})
+
+	b.AddPeer(server.PeerConfig{
+		AdminEnabled:      true,
+		LocalAS:           65200,
+		PeerAS:            65100,
+		PeerAddress:       bnet.IPv4FromOctets(172, 17, 0, 2).Ptr(),
+		LocalAddress:      bnet.IPv4FromOctets(169, 254, 100, 1).Ptr(),
+		ReconnectInterval: time.Second * 15,
+		HoldTime:          time.Second * 90,
+		KeepAlive:         time.Second * 30,
+		Passive:           true,
+		RouterID:          b.RouterID(),
+		IPv4: &server.AddressFamilyConfig{
+			ImportFilterChain: filter.NewAcceptAllFilterChain(),
+			ExportFilterChain: filter.NewAcceptAllFilterChain(),
+			AddPathSend: routingtable.ClientOptions{
+				MaxPaths: 10,
+			},
+			AddPathRecv: true,
+		},
+		RouteServerClient: true,
+		VRF:               v,
 	})
 }

--- a/examples/bgp/main.go
+++ b/examples/bgp/main.go
@@ -1,36 +1,60 @@
 package main
 
 import (
+	"flag"
+	"log"
+	"net"
 	"net/http"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"google.golang.org/grpc"
 
 	prom_bgp "github.com/bio-routing/bio-rd/metrics/bgp/adapter/prom"
 	prom_vrf "github.com/bio-routing/bio-rd/metrics/vrf/adapter/prom"
-	bnet "github.com/bio-routing/bio-rd/net"
+	api "github.com/bio-routing/bio-rd/protocols/bgp/api"
 	"github.com/bio-routing/bio-rd/protocols/bgp/server"
 	"github.com/bio-routing/bio-rd/routingtable/vrf"
 	"github.com/sirupsen/logrus"
 )
 
-func strAddr(s string) uint32 {
-	ret, _ := bnet.StrToAddr(s)
-	return ret
-}
-
 func main() {
+	ipv4 := flag.Bool("ipv4", true, "Enable IPv4 Listener and AFI")
+	ipv6 := flag.Bool("ipv6", true, "Enable IPv6 Listener and AFI")
+	flag.Parse()
+
 	logrus.Printf("This is a BGP speaker\n")
 
-	b := server.NewBGPServer(0, []string{"127.0.0.1:0"})
+	listen := []string{}
+
+	if *ipv4 {
+		listen = append(listen, "0.0.0.0:179")
+	}
+
+	if *ipv6 {
+		listen = append(listen, "[::]:179")
+	}
+
+	b := server.NewBGPServer(0, listen)
 	v, err := vrf.New("master", 0)
 	if err != nil {
 		logrus.Fatal(err)
 	}
 
 	go startMetricsEndpoint(b)
+	go startAPIEndpoint(b)
 
-	startServer(b, v)
+	if err := b.Start(); err != nil {
+		log.Fatalf("Unable to start BGP server: %v", err)
+	}
+
+	if *ipv4 {
+		addPeersIPv4(b, v)
+	}
+
+	if *ipv6 {
+		addPeersIPv6(b, v)
+	}
 
 	select {}
 }
@@ -43,4 +67,18 @@ func startMetricsEndpoint(server server.BGPServer) {
 
 	logrus.Info("Metrics are available :8080/metrics")
 	logrus.Error(http.ListenAndServe(":8080", nil))
+}
+
+func startAPIEndpoint(b server.BGPServer) {
+	apiSrv := server.NewBGPAPIServer(b)
+
+	lis, err := net.Listen("tcp", ":1337")
+	if err != nil {
+		log.Fatalf("failed to listen: %v", err)
+	}
+	grpcServer := grpc.NewServer()
+	api.RegisterBgpServiceServer(grpcServer, apiSrv)
+	if err := grpcServer.Serve(lis); err != nil {
+		log.Fatalf("failed to serve: %v", err)
+	}
 }


### PR DESCRIPTION
The second IPv6 was missing the VRF line and the example was not working therefore.
I tried to simplify and streamline the example a little bit. This also removes the need for build tags to differentiate between IPv4 and IPv6.