### PR TITLE
fix: nil pointer for local address with ebgp

### DIFF
--- a/protocols/bgp/server/peer.go
+++ b/protocols/bgp/server/peer.go
@@ -269,6 +269,7 @@ func newPeer(c PeerConfig, server *bgpServer) (*peer, error) {
 		server:               server,
 		config:               &c,
 		addr:                 c.PeerAddress,
+		localAddr:            c.LocalAddress,
 		ttl:                  c.TTL,
 		passive:              c.Passive,
 		peerASN:              c.PeerAS,


### PR DESCRIPTION
eBGP was broken because of this forgotten attribute.