### PR TITLE
fix: metrics for bgp labels cardinality

### DIFF
--- a/metrics/bgp/adapter/prom/bgp_prom_adapter.go
+++ b/metrics/bgp/adapter/prom/bgp_prom_adapter.go
@@ -169,7 +169,7 @@ func collectForFamily(ch chan<- prometheus.Metric, family *metrics.BGPAddressFam
 	if family.EndOfRIBMarkerReceived {
 		eor = 1
 	}
-	ch <- prometheus.MustNewConstMetric(endOfRIBMarkerDesc, prometheus.GaugeValue, float64(eor))
+	ch <- prometheus.MustNewConstMetric(endOfRIBMarkerDesc, prometheus.GaugeValue, float64(eor), l...)
 }
 
 func collectForFamilyRouter(ch chan<- prometheus.Metric, family *metrics.BGPAddressFamilyMetrics, l []string) {


### PR DESCRIPTION
Fixing the label cardinality issue for metrics when a peer is established:

```
go run ./examples/bgp
INFO[0000] This is a BGP speaker                        
INFO[0000] Metrics are available :8080/metrics          
INFO[0000] Added BGP peer                                local_address=127.0.0.1 local_as=65200 peer_address=127.0.0.1 peer_as=65300
INFO[0000] Added BGP peer                                local_address="2001:678:1e0::cafe" local_as=65200 peer_address="2001:678:1e0::1" peer_as=65300
INFO[0000] Added BGP peer                                local_address="2001:678:1e0::cafe" local_as=65200 peer_address="2001:678:1e0:cafe::5" peer_as=65400
INFO[0009] Incoming TCP connection                       source="127.0.0.1:36775"
INFO[0009] FSM: Neighbor state change                    last_state=active new_state=openSent peer=127.0.0.1 reason="Sent OPEN message"
INFO[0009] FSM: Neighbor state change                    last_state=openSent new_state=openConfirm peer=127.0.0.1 reason="Received OPEN message"
INFO[0009] FSM: Neighbor state change                    last_state=openConfirm new_state=established peer=127.0.0.1 reason="Received KEEPALIVE"
panic: inconsistent label cardinality: expected 6 label values but got 0 in []string(nil)
```