### PR TITLE
Allow setting default Local Preference for eBGP sessions and default it to 100.

### DIFF
--- a/cmd/bio-rd/main.go
+++ b/cmd/bio-rd/main.go
@@ -68,11 +68,12 @@ func main() {
 		},
 	}
 
-	bgpSrv = bgpserver.NewBGPServer(
-		startCfg.RoutingOptions.RouterIDUint32,
-		vrfReg.CreateVRFIfNotExists(vrf.DefaultVRFName, 0),
-		listenAddrsByVRF,
-	)
+	bgpSrvCfg := bgpserver.BGPServerConfig{
+		RouterID:         startCfg.RoutingOptions.RouterIDUint32,
+		DefaultVRF:       vrfReg.CreateVRFIfNotExists(vrf.DefaultVRFName, 0),
+		ListenAddrsByVRF: listenAddrsByVRF,
+	}
+	bgpSrv = bgpserver.NewBGPServer(bgpSrvCfg)
 
 	err = bgpSrv.Start()
 	if err != nil {

--- a/examples/bgp/main.go
+++ b/examples/bgp/main.go
@@ -40,7 +40,12 @@ func main() {
 		logrus.Fatal(err)
 	}
 
-	b := server.NewBGPServer(0, v, map[string][]string{vrf.DefaultVRFName: listen})
+	bCfg := server.BGPServerConfig{
+		RouterID:         0,
+		DefaultVRF:       v,
+		ListenAddrsByVRF: map[string][]string{vrf.DefaultVRFName: listen},
+	}
+	b := server.NewBGPServer(bCfg)
 
 	go startMetricsEndpoint(b)
 	go startAPIEndpoint(b, vrf.GetGlobalRegistry())

--- a/protocols/bgp/server/fsm_address_family.go
+++ b/protocols/bgp/server/fsm_address_family.go
@@ -115,7 +115,7 @@ func (f *fsmAddressFamily) init() {
 func (f *fsmAddressFamily) getSessionAttrs() routingtable.SessionAttrs {
 	rip, _ := bnet.IPFromBytes(f.fsm.bmpRouterAddress)
 
-	return routingtable.SessionAttrs{
+	sa := routingtable.SessionAttrs{
 		RouterID:             f.fsm.peer.routerID,
 		PeerIP:               f.fsm.peer.addr,
 		LocalIP:              f.fsm.peer.localAddr,
@@ -138,6 +138,13 @@ func (f *fsmAddressFamily) getSessionAttrs() routingtable.SessionAttrs {
 		// Only relevant for BMP use
 		RouterIP: rip,
 	}
+
+	// Only set Default Local Preference for BGP and when peer is fully set up (may not be the case in tests, to be fixed)
+	if !f.fsm.isBMP && f.fsm.peer.server != nil {
+		sa.DefaultLocalPreference = *f.fsm.peer.server.config.DefaultLocalPreference
+	}
+
+	return sa
 }
 
 func (f *fsmAddressFamily) bmpInit() {

--- a/protocols/bgp/server/metrics_service_test.go
+++ b/protocols/bgp/server/metrics_service_test.go
@@ -17,6 +17,12 @@ func TestMetrics(t *testing.T) {
 	vrf := vrf.NewUntrackedVRF("inet.0", 0)
 	establishedTime := time.Now()
 
+	BGPServerConfig := BGPServerConfig{
+		ListenAddrsByVRF: nil,
+		DefaultVRF:       vrf,
+		RouterID:         0,
+	}
+
 	tests := []struct {
 		name               string
 		peer               *peer
@@ -242,7 +248,7 @@ func TestMetrics(t *testing.T) {
 				fsm.establishedTime = establishedTime
 			}
 
-			s := newBGPServer(0, vrf, nil)
+			s := newBGPServer(BGPServerConfig)
 			s.peers.add(test.peer)
 
 			actual, err := s.Metrics()

--- a/routingtable/adjRIBIn/adj_rib_in.go
+++ b/routingtable/adjRIBIn/adj_rib_in.go
@@ -182,6 +182,11 @@ func (a *AdjRIBIn) addPath(pfx *net.Prefix, p *route.Path) error {
 		return nil
 	}
 
+	// RFC4277 Sect 8. suggest to set a  use Local Preference as default value for eBGP
+	if !a.sessionAttrs.IBGP && p.BGPPath.BGPPathA.LocalPref == 0 {
+		p.BGPPath.BGPPathA.LocalPref = a.sessionAttrs.DefaultLocalPreference
+	}
+
 	for _, client := range a.clientManager.Clients() {
 		client.AddPath(pfx, p)
 	}

--- a/routingtable/session_attrs.go
+++ b/routingtable/session_attrs.go
@@ -7,6 +7,9 @@ type SessionAttrs struct {
 	// RouterID is the ID of the local router
 	RouterID uint32
 
+	// The default local-preference value if none is learned via eBGP
+	DefaultLocalPreference uint32
+
 	// PeerIP is the IP address of the neighbor
 	PeerIP *bnet.IP
 


### PR DESCRIPTION
RFC4277 Section 8. states that 100 is a - if not the - common value for Local Preference on eBGP sessions, where it would be 0 if none is set.  To increase interoperability with other BGP speakers we now allow setting a default value for Local Preference for the BGP server and default to 100 if none was set.

Closes #400

