### PR TITLE
Index VRFs by name instead of RD

### DIFF
--- a/cmd/bio-rd/main.go
+++ b/cmd/bio-rd/main.go
@@ -75,7 +75,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	vrfReg.CreateVRFIfNotExists("master", 0)
+	vrfReg.CreateVRFIfNotExists(vrf.DefaultVRFName, 0)
 
 	go configReloader()
 	sigHUP <- syscall.SIGHUP
@@ -182,7 +182,7 @@ func configureProtocolsBGP(bgp *config.BGP) error {
 	// Tear down peers that need new sessions as they changed too significantly
 	for _, g := range bgp.Groups {
 		for _, n := range g.Neighbors {
-			newCfg := BGPPeerConfig(n, vrfReg.GetVRFByRD(0))
+			newCfg := BGPPeerConfig(n, vrfReg.GetVRFByName(vrf.DefaultVRFName))
 			oldCfg := bgpSrv.GetPeerConfig(n.PeerAddressIP)
 			if oldCfg == nil {
 				continue
@@ -205,7 +205,7 @@ func configureProtocolsBGP(bgp *config.BGP) error {
 				continue
 			}
 
-			newCfg := BGPPeerConfig(n, vrfReg.GetVRFByRD(0))
+			newCfg := BGPPeerConfig(n, vrfReg.GetVRFByName(vrf.DefaultVRFName))
 			err := bgpSrv.AddPeer(*newCfg)
 			if err != nil {
 				return fmt.Errorf("unable to add BGP peer: %w", err)

--- a/cmd/ris-mirror/rismirror/router.go
+++ b/cmd/ris-mirror/rismirror/router.go
@@ -42,9 +42,9 @@ func (r *Router) Ready(vrf uint64, afi uint16) bool {
 	return true
 }
 
-// GetVRF gets a VRF by its ID
-func (r *Router) GetVRF(vrfID uint64) *vrf.VRF {
-	return r.vrfRegistry.GetVRFByRD(vrfID)
+// GetVRF gets a VRF by its RD
+func (r *Router) GetVRF(rd uint64) *vrf.VRF {
+	return r.vrfRegistry.GetVRFByName(vrf.RouteDistinguisherHumanReadable(rd))
 }
 
 // GetVRFs gets all VRFs

--- a/protocols/bgp/server/bmp_router.go
+++ b/protocols/bgp/server/bmp_router.go
@@ -147,7 +147,7 @@ func neighborsIncludeVRF(neighbors []*neighbor, vrfID uint64) bool {
 
 // GetVRF get's a VRF
 func (r *Router) GetVRF(rd uint64) *vrf.VRF {
-	return r.vrfRegistry.GetVRFByRD(rd)
+	return r.vrfRegistry.GetVRFByName(vrf.RouteDistinguisherHumanReadable(rd))
 }
 
 // GetVRFs gets all VRFs
@@ -408,7 +408,7 @@ func (r *Router) processPeerUpNotification(msg *bmppkt.PeerUpNotification) error
 			localASN:        uint32(sentOpen.ASN),
 			ipv4:            &peerAddressFamily{},
 			ipv6:            &peerAddressFamily{},
-			vrf:             r.vrfRegistry.CreateVRFIfNotExists(fmt.Sprintf("%d", msg.PerPeerHeader.PeerDistinguisher), msg.PerPeerHeader.PeerDistinguisher),
+			vrf:             r.vrfRegistry.CreateVRFIfNotExists(vrf.RouteDistinguisherHumanReadable(msg.PerPeerHeader.PeerDistinguisher), msg.PerPeerHeader.PeerDistinguisher),
 			adjRIBInFactory: r.adjRIBInFactory,
 		},
 	}

--- a/routingtable/vrf/vrf.go
+++ b/routingtable/vrf/vrf.go
@@ -9,6 +9,8 @@ import (
 	"github.com/bio-routing/bio-rd/routingtable/locRIB"
 )
 
+const DefaultVRFName = "main"
+
 const (
 	afiIPv4     = 1
 	afiIPv6     = 2

--- a/routingtable/vrf/vrf_test.go
+++ b/routingtable/vrf/vrf_test.go
@@ -62,12 +62,12 @@ func TestUnregister(t *testing.T) {
 	_, err = New(vrfName, 10)
 	assert.NotNil(t, err, "error must not be nil on second invokation")
 
-	_, found := globalRegistry.vrfs[10]
+	_, found := globalRegistry.vrfs[vrfName]
 	assert.True(t, found, "vrf must be in global registry")
 
 	v.Unregister()
 
-	_, found = globalRegistry.vrfs[10]
+	_, found = globalRegistry.vrfs[vrfName]
 	assert.False(t, found, "vrf must not be in global registry")
 
 }
@@ -85,6 +85,11 @@ func TestRouteDistinguisherHumanReadable(t *testing.T) {
 		},
 		{
 			name:     "Test #2",
+			rdi:      123,
+			expected: "0:123",
+		},
+		{
+			name:     "Test #3",
 			rdi:      220434901565105,
 			expected: "51324:65201",
 		},


### PR DESCRIPTION
If we only know the RD (because we only get the RD for BMP for example),  we use the human readable version of the RD as VRF name.
