### PR TITLE
Fix: Repair ObserveRib for IPv6

### DIFF
--- a/cmd/ris-mirror/rismirror/router.go
+++ b/cmd/ris-mirror/rismirror/router.go
@@ -38,8 +38,8 @@ func (r *Router) Address() net.IP {
 	return r.address
 }
 
-func (r *Router) Ready(vrf uint64, afi uint16) bool {
-	return true
+func (r *Router) Ready(vrf uint64, afi uint16) (bool, error) {
+	return true, nil
 }
 
 // GetVRF gets a VRF by its RD

--- a/cmd/ris/risserver/server.go
+++ b/cmd/ris/risserver/server.go
@@ -193,7 +193,7 @@ func (s *Server) ObserveRIB(req *pb.ObserveRIBRequest, stream pb.RoutingInformat
 		return status.New(codes.Unavailable, wrapGetRIBErr(err, req.Router, vrfID, ipVersion).Error()).Err()
 	}
 
-	if !s.bmp.GetRouter(req.Router).Ready(vrfID, ipVersionFromProto(ipVersion)) {
+	if ready, err := s.bmp.GetRouter(req.Router).Ready(vrfID, ipVersionFromProto(ipVersion)); !ready {
 		return status.New(codes.Unavailable, wrapRIBNotReadyErr(err, req.Router, vrfID, ipVersion).Error()).Err()
 	}
 

--- a/protocols/bgp/server/bmp_router_test.go
+++ b/protocols/bgp/server/bmp_router_test.go
@@ -131,7 +131,7 @@ func TestReady(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		res := test.r.Ready(test.vrf, test.afi)
+		res, _ := test.r.Ready(test.vrf, test.afi)
 		assert.Equal(t, test.expected, res, test.name)
 	}
 }

--- a/protocols/bgp/server/fsm_address_family.go
+++ b/protocols/bgp/server/fsm_address_family.go
@@ -202,6 +202,11 @@ func (f *fsmAddressFamily) processUpdate(u *packet.BGPUpdate, bmpPostPolicy bool
 		f.withdraws(u, bmpPostPolicy, timestamp)
 		f.updates(u, bmpPostPolicy, timestamp)
 	}
+	if f.afi == packet.AFIIPv6 {
+		if u.IsEndOfRIBMarker() {
+			f.endOfRIBMarkerReceived.Store(true)
+		}
+	}
 }
 
 func (f *fsmAddressFamily) withdraws(u *packet.BGPUpdate, bmpPostPolicy bool, timestamp uint32) {


### PR DESCRIPTION
ObserveRib did not work for IPv6, as the RIB was never marked as ready.
This is solved by honoring the endOfRibMarker also for v6.

Also, a some more verbose error messages are added to the rib readyness probe.