### PR TITLE
riscli fix logging and allow encrypted grpc

### DIFF
--- a/cmd/riscli/dump_loc_rib.go
+++ b/cmd/riscli/dump_loc_rib.go
@@ -9,7 +9,6 @@ import (
 	pb "github.com/bio-routing/bio-rd/cmd/ris/api"
 	"github.com/bio-routing/bio-rd/util/log"
 	"github.com/urfave/cli"
-	"google.golang.org/grpc"
 )
 
 // NewDumpLocRIBCommand creates a new dump local rib command
@@ -27,12 +26,9 @@ func NewDumpLocRIBCommand() cli.Command {
 	}
 
 	cmd.Action = func(c *cli.Context) error {
-		conn, err := grpc.Dial(c.GlobalString("ris"), grpc.WithInsecure())
-		if err != nil {
-			log.Errorf("GRPC dial failed: %v", err)
-			os.Exit(1)
-		}
+		conn := SetupGRPCClient(c)
 		defer conn.Close()
+		var err error
 
 		afisafis := make([]pb.DumpRIBRequest_AFISAFI, 0)
 		req_ipv4, req_ipv6 := c.Bool("4"), c.Bool("6")

--- a/cmd/riscli/grpc.go
+++ b/cmd/riscli/grpc.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"crypto/tls"
+	"os"
+
+	"github.com/bio-routing/bio-rd/util/log"
+	"github.com/urfave/cli"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+)
+
+func SetupGRPCClient(c *cli.Context) *grpc.ClientConn {
+	grpcDial := grpc.WithInsecure()
+	if c.GlobalBool("tls") {
+		config := &tls.Config{}
+		grpcDial = grpc.WithTransportCredentials(credentials.NewTLS(config))
+	}
+	conn, err := grpc.Dial(c.GlobalString("ris"), grpcDial)
+	if err != nil {
+		log.WithError(err).Error("GRPC dial failed: %v")
+		os.Exit(1)
+	}
+	return conn
+}

--- a/cmd/riscli/lpm.go
+++ b/cmd/riscli/lpm.go
@@ -9,7 +9,6 @@ import (
 	bnet "github.com/bio-routing/bio-rd/net"
 	"github.com/bio-routing/bio-rd/util/log"
 	"github.com/urfave/cli"
-	"google.golang.org/grpc"
 )
 
 // NewLPMCommand creates a new LPM command
@@ -23,11 +22,7 @@ func NewLPMCommand() cli.Command {
 	}
 
 	cmd.Action = func(c *cli.Context) error {
-		conn, err := grpc.Dial(c.GlobalString("ris"), grpc.WithInsecure())
-		if err != nil {
-			log.Errorf("GRPC dial failed: %v", err)
-			os.Exit(1)
-		}
+		conn := SetupGRPCClient(c)
 		defer conn.Close()
 
 		ipAddr, err := bnet.IPFromString(c.String("ip"))

--- a/cmd/riscli/main.go
+++ b/cmd/riscli/main.go
@@ -3,12 +3,18 @@ package main
 import (
 	"os"
 
+	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 
 	"github.com/bio-routing/bio-rd/util/log"
 )
 
 func main() {
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.InfoLevel)
+	log.SetLogger(log.NewLogrusWrapper(logger))
+
 	app := cli.NewApp()
 	app.Name = "riscli"
 	app.Usage = "RIS CLI"
@@ -32,6 +38,10 @@ func main() {
 			Name:  "vrf",
 			Usage: "VRF",
 			Value: "",
+		},
+		cli.BoolFlag{
+			Name:  "tls",
+			Usage: "use a tls-encrypted grpc connection to the ris",
 		},
 	}
 

--- a/cmd/riscli/observe_rib.go
+++ b/cmd/riscli/observe_rib.go
@@ -9,7 +9,6 @@ import (
 	pb "github.com/bio-routing/bio-rd/cmd/ris/api"
 	"github.com/bio-routing/bio-rd/util/log"
 	"github.com/urfave/cli"
-	"google.golang.org/grpc"
 )
 
 // NewObserveRIBCommand creates a new observe rib command
@@ -24,12 +23,9 @@ func NewObserveRIBCommand() cli.Command {
 	}
 
 	cmd.Action = func(c *cli.Context) error {
-		conn, err := grpc.Dial(c.GlobalString("ris"), grpc.WithInsecure())
-		if err != nil {
-			log.Errorf("GRPC dial failed: %v", err)
-			os.Exit(1)
-		}
+		conn := SetupGRPCClient(c)
 		defer conn.Close()
+		var err error
 
 		afisafis := make([]pb.ObserveRIBRequest_AFISAFI, 0)
 		reqIPv4, reqIPv6 := c.Bool("4"), c.Bool("6")
@@ -48,7 +44,7 @@ func NewObserveRIBCommand() cli.Command {
 			fmt.Printf(" --- Dump %s ---\n", pb.DumpRIBRequest_AFISAFI_name[int32(afisafi)])
 			err = observeRIB(client, c.GlobalString("router"), c.GlobalUint64("vrf_id"), c.GlobalString("vrf"), afisafi)
 			if err != nil {
-				log.Errorf("DumpRIB failed: %v", err)
+				log.Errorf("ObserveRIB failed: %v", err)
 				os.Exit(1)
 			}
 		}


### PR DESCRIPTION
With this PR, the logging is adjusted to the new bio log util (and working again).
Also, all riscli grpc dialups are extracted to a common function. Support for Server-Side TLS is added.