### PR TITLE
ris-mirror: Add API for removing one or all vrf ris clients at runtime

### DIFF
--- a/cmd/ris-mirror/rismirror/vrf.go
+++ b/cmd/ris-mirror/rismirror/vrf.go
@@ -1,6 +1,7 @@
 package rismirror
 
 import (
+	"github.com/bio-routing/bio-rd/risclient"
 	"github.com/bio-routing/bio-rd/routingtable/locRIB"
 	"github.com/bio-routing/bio-rd/routingtable/mergedlocrib"
 	"github.com/bio-routing/bio-rd/routingtable/vrf"
@@ -10,12 +11,15 @@ type vrfWithMergedLocRIBs struct {
 	vrf         *vrf.VRF
 	ipv4Unicast *mergedlocrib.MergedLocRIB
 	ipv6Unicast *mergedlocrib.MergedLocRIB
+	Clients     []*risclient.RISClient
 }
 
-func newVRFWithMergedLocRIBs(locRIBIPv4Unicast, locRIBIPv6Unicast *locRIB.LocRIB) *vrfWithMergedLocRIBs {
+func newVRFWithMergedLocRIBs(locRIBIPv4Unicast, locRIBIPv6Unicast *locRIB.LocRIB, v *vrf.VRF) *vrfWithMergedLocRIBs {
 	return &vrfWithMergedLocRIBs{
+		vrf:         v,
 		ipv4Unicast: mergedlocrib.New(locRIBIPv4Unicast),
 		ipv6Unicast: mergedlocrib.New(locRIBIPv6Unicast),
+		Clients:     make([]*risclient.RISClient, 0, 2),
 	}
 }
 


### PR DESCRIPTION
When using the ris-mirror API, it was only possible to add new VRFs, but not remove vrfs from the ris-mirror at runtime.
This leads to problems when for example an vrf/router is not available any longer, but cannot be removed from the ris-mirror, leading to failing observeRIB calls.
This PR adds basic support for gracefully removing an router/VRF at runtime.