### PR TITLE
net/tcp: use SetsockoptTCPMD5Sig from golang.org/x/sys/unix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/bio-routing/bio-rd
 
 require (
+	github.com/benbjohnson/clock v1.3.0
 	github.com/bio-routing/tflow2 v0.0.0-20181230153523-2e308a4a3c3a
 	github.com/grpc-ecosystem/go-grpc-middleware v1.0.0
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
@@ -10,14 +11,13 @@ require (
 	github.com/urfave/cli v1.21.0
 	github.com/vishvananda/netlink v1.0.0
 	go.uber.org/zap v1.24.0
-	golang.org/x/sys v0.0.0-20211124211545-fe61309f8881
+	golang.org/x/sys v0.6.0
 	google.golang.org/grpc v1.42.0
 	google.golang.org/protobuf v1.27.1
 	gopkg.in/yaml.v2 v2.2.8
 )
 
 require (
-	github.com/benbjohnson/clock v1.3.0 // indirect
 	github.com/beorn7/perks v1.0.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -161,8 +161,8 @@ golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211124211545-fe61309f8881 h1:TyHqChC80pFkXWraUUf6RuB5IqFdQieMLwwCJokV2pc=
-golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
+golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/net/tcp/md5sig.go
+++ b/net/tcp/md5sig.go
@@ -2,53 +2,35 @@ package tcp
 
 import (
 	"net"
-	"unsafe"
 
 	"golang.org/x/sys/unix"
 )
 
 const (
-	tcpMD5SIG           = 14 // (RFC2385)
-	tcpMD5SIGMaxKeyLen  = 80
 	tcpMD5SIGFlagPrefix = 0
 )
 
-type tcpMD5sig struct {
-	ssFamily  uint16
-	ss        [126]byte
-	flags     uint8
-	prefixLen uint8
-	keylen    uint16
-	ifIndex   uint32
-	key       [tcpMD5SIGMaxKeyLen]byte
-}
-
-func buildTCPMD5Sig(addr net.IP, key string) tcpMD5sig {
-	family := unix.AF_INET
-	if addr.To4() == nil {
-		family = unix.AF_INET6
+func buildTCPMD5Sig(addr net.IP, key string) *unix.TCPMD5Sig {
+	t := &unix.TCPMD5Sig{
+		Flags:     tcpMD5SIGFlagPrefix,
+		Prefixlen: 0,
+		Keylen:    uint16(len(key)),
 	}
 
-	t := tcpMD5sig{
-		ssFamily:  uint16(family),
-		flags:     tcpMD5SIGFlagPrefix,
-		prefixLen: 0,
-		keylen:    uint16(len(key)),
-	}
-
-	if family == unix.AF_INET {
-		copy(t.ss[2:], addr.To4())
+	if addr.To4() != nil {
+		t.Addr.Family = unix.AF_INET
+		copy(t.Addr.Data[2:], addr.To4())
 	} else {
-		copy(t.ss[6:], addr.To16())
+		t.Addr.Family = unix.AF_INET6
+		copy(t.Addr.Data[6:], addr.To16())
 	}
 
-	copy(t.key[0:], key)
+	copy(t.Key[0:], key)
 
 	return t
 }
 
 func setTCPMD5Option(fd int, addr net.IP, md5secret string) error {
 	sig := buildTCPMD5Sig(addr, md5secret)
-	b := *(*[unsafe.Sizeof(sig)]byte)(unsafe.Pointer(&sig))
-	return unix.SetsockoptString(fd, unix.IPPROTO_TCP, tcpMD5SIG, string(b[:]))
+	return unix.SetsockoptTCPMD5Sig(fd, unix.IPPROTO_TCP, unix.TCP_MD5SIG, sig)
 }


### PR DESCRIPTION
Use the TCPMD5Sig type and its corresponding SetsockoptTCPMD5Sig helper added in x/sys v0.6.0 to set the TCP MD5 sig on a socket.