### PR TITLE
bio-rd BGP configuration refactoring

### DIFF
--- a/cmd/bio-rd/bgp.go
+++ b/cmd/bio-rd/bgp.go
@@ -156,6 +156,14 @@ func (c *bgpConfigurator) newPeerConfig(bn *config.BGPNeighbor, bg *config.BGPGr
 		p.RouteServerClient = *bn.RouteServerClient
 	}
 
+	if bn.RouteReflectorClient != nil {
+		p.RouteReflectorClient = *bn.RouteReflectorClient
+	}
+
+	if bn.ClusterIDIP != nil {
+		p.RouteReflectorClusterID = bn.ClusterIDIP.ToUint32()
+	}
+
 	return p
 }
 

--- a/cmd/bio-rd/bgp.go
+++ b/cmd/bio-rd/bgp.go
@@ -11,6 +11,10 @@ import (
 	"github.com/bio-routing/bio-rd/routingtable/vrf"
 )
 
+const (
+	DefaultReconnectInterval = time.Second * 15
+)
+
 type bgpConfigurator struct {
 	srv bgpserver.BGPServer
 }
@@ -107,7 +111,7 @@ func (c *bgpConfigurator) newPeerConfig(bn *config.BGPNeighbor, bg *config.BGPGr
 		PeerAddress:       bn.PeerAddressIP,
 		LocalAddress:      bn.LocalAddressIP,
 		TTL:               bn.TTL,
-		ReconnectInterval: time.Second * 15,
+		ReconnectInterval: DefaultReconnectInterval,
 		HoldTime:          bn.HoldTimeDuration,
 		KeepAlive:         bn.HoldTimeDuration / 3,
 		RouterID:          c.srv.RouterID(),

--- a/cmd/bio-rd/bgp.go
+++ b/cmd/bio-rd/bgp.go
@@ -20,8 +20,6 @@ type bgpConfigurator struct {
 }
 
 func (c *bgpConfigurator) configure(cfg *config.BGP) error {
-	c.deconfigureRemovedSessions(cfg)
-
 	for _, bg := range cfg.Groups {
 		for _, bn := range bg.Neighbors {
 			err := c.configureSession(bn, bg)
@@ -30,6 +28,8 @@ func (c *bgpConfigurator) configure(cfg *config.BGP) error {
 			}
 		}
 	}
+
+	c.deconfigureRemovedSessions(cfg)
 
 	return nil
 }

--- a/cmd/bio-rd/bgp.go
+++ b/cmd/bio-rd/bgp.go
@@ -104,18 +104,19 @@ func (c *bgpConfigurator) configureNewSessions(cfg *config.BGP) error {
 
 func (c *bgpConfigurator) newPeerConfig(bn *config.BGPNeighbor, bg *config.BGPGroup, vrf *vrf.VRF) *bgpserver.PeerConfig {
 	p := &bgpserver.PeerConfig{
-		AdminEnabled:      !bn.Disabled,
-		AuthenticationKey: bn.AuthenticationKey,
-		LocalAS:           bn.LocalAS,
-		PeerAS:            bn.PeerAS,
-		PeerAddress:       bn.PeerAddressIP,
-		LocalAddress:      bn.LocalAddressIP,
-		TTL:               bn.TTL,
-		ReconnectInterval: DefaultReconnectInterval,
-		HoldTime:          bn.HoldTimeDuration,
-		KeepAlive:         bn.HoldTimeDuration / 3,
-		RouterID:          c.srv.RouterID(),
-		VRF:               vrf,
+		AdminEnabled:               !bn.Disabled,
+		AuthenticationKey:          bn.AuthenticationKey,
+		LocalAS:                    bn.LocalAS,
+		PeerAS:                     bn.PeerAS,
+		PeerAddress:                bn.PeerAddressIP,
+		LocalAddress:               bn.LocalAddressIP,
+		TTL:                        bn.TTL,
+		ReconnectInterval:          DefaultReconnectInterval,
+		HoldTime:                   bn.HoldTimeDuration,
+		KeepAlive:                  bn.HoldTimeDuration / 3,
+		RouterID:                   c.srv.RouterID(),
+		VRF:                        vrf,
+		AdvertiseIPv4MultiProtocol: bn.AdvertiseIPv4MultiProtocol,
 	}
 
 	c.configureIPv4(bn, bg, p)

--- a/cmd/bio-rd/bgp.go
+++ b/cmd/bio-rd/bgp.go
@@ -59,12 +59,16 @@ func (c *bgpConfigurator) reconfigureModifiedSessions(cfg *config.BGP) error {
 			}
 
 			if !oldCfg.NeedsRestart(newCfg) {
-				c.srv.ReplaceImportFilterChain(c.srv.GetDefaultVRF(),
+				c.srv.ReplaceImportFilterChain(
+					c.srv.GetDefaultVRF(),
 					bn.PeerAddressIP,
-					c.determineFilterChain(bg.ImportFilterChain, bn.ImportFilterChain))
-				c.srv.ReplaceExportFilterChain(c.srv.GetDefaultVRF(),
+					c.determineFilterChain(bg.ImportFilterChain, bn.ImportFilterChain),
+				)
+				c.srv.ReplaceExportFilterChain(
+					c.srv.GetDefaultVRF(),
 					bn.PeerAddressIP,
-					c.determineFilterChain(bg.ExportFilterChain, bn.ExportFilterChain))
+					c.determineFilterChain(bg.ExportFilterChain, bn.ExportFilterChain),
+				)
 				continue
 			}
 

--- a/cmd/bio-rd/bgp.go
+++ b/cmd/bio-rd/bgp.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/bio-routing/bio-rd/cmd/bio-rd/config"
+	bgpserver "github.com/bio-routing/bio-rd/protocols/bgp/server"
+	"github.com/bio-routing/bio-rd/routingtable"
+	"github.com/bio-routing/bio-rd/routingtable/vrf"
+)
+
+func configureProtocolsBGP(bgp *config.BGP) error {
+	// Tear down peers that are to be removed
+	for _, p := range bgpSrv.GetPeers() {
+		found := false
+		for _, g := range bgp.Groups {
+			for _, n := range g.Neighbors {
+				if n.PeerAddressIP == p.Addr() && p.VRF() == bgpSrv.GetDefaultVRF() {
+					found = true
+					break
+				}
+			}
+		}
+
+		if !found {
+			bgpSrv.DisposePeer(bgpSrv.GetDefaultVRF(), p.Addr())
+		}
+	}
+
+	// Tear down peers that need new sessions as they changed too significantly
+	for _, g := range bgp.Groups {
+		for _, n := range g.Neighbors {
+			newCfg := toBGPPeerConfig(n, bgpSrv.GetDefaultVRF())
+			oldCfg := bgpSrv.GetPeerConfig(bgpSrv.GetDefaultVRF(), n.PeerAddressIP)
+			if oldCfg == nil {
+				continue
+			}
+
+			if !oldCfg.NeedsRestart(newCfg) {
+				bgpSrv.ReplaceImportFilterChain(bgpSrv.GetDefaultVRF(), n.PeerAddressIP, newCfg.IPv4.ImportFilterChain)
+				bgpSrv.ReplaceExportFilterChain(bgpSrv.GetDefaultVRF(), n.PeerAddressIP, newCfg.IPv4.ExportFilterChain)
+				continue
+			}
+
+			bgpSrv.DisposePeer(bgpSrv.GetDefaultVRF(), oldCfg.PeerAddress)
+		}
+	}
+
+	// Turn up all sessions that are missing
+	for _, g := range bgp.Groups {
+		for _, n := range g.Neighbors {
+			if bgpSrv.GetPeerConfig(bgpSrv.GetDefaultVRF(), n.PeerAddressIP) != nil {
+				continue
+			}
+
+			newCfg := toBGPPeerConfig(n, vrfReg.GetVRFByName(vrf.DefaultVRFName))
+			err := bgpSrv.AddPeer(*newCfg)
+			if err != nil {
+				return fmt.Errorf("unable to add BGP peer: %w", err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// BGPPeerConfig converts a BGPNeighbor config into a PeerConfig
+func toBGPPeerConfig(n *config.BGPNeighbor, vrf *vrf.VRF) *bgpserver.PeerConfig {
+	r := &bgpserver.PeerConfig{
+		AdminEnabled:      !n.Disabled,
+		AuthenticationKey: n.AuthenticationKey,
+		LocalAS:           n.LocalAS,
+		PeerAS:            n.PeerAS,
+		PeerAddress:       n.PeerAddressIP,
+		LocalAddress:      n.LocalAddressIP,
+		TTL:               n.TTL,
+		ReconnectInterval: time.Second * 15,
+		HoldTime:          n.HoldTimeDuration,
+		KeepAlive:         n.HoldTimeDuration / 3,
+		RouterID:          bgpSrv.RouterID(),
+		IPv4: &bgpserver.AddressFamilyConfig{
+			ImportFilterChain: n.ImportFilterChain,
+			ExportFilterChain: n.ExportFilterChain,
+			AddPathSend: routingtable.ClientOptions{
+				MaxPaths: 10,
+			},
+		},
+		VRF: vrf,
+	}
+
+	// TODO: configureAFIsForBGPPeer(n, r)
+
+	if n.Passive != nil {
+		r.Passive = *n.Passive
+	}
+
+	if n.RouteServerClient != nil {
+		r.RouteServerClient = *n.RouteServerClient
+	}
+
+	return r
+}

--- a/cmd/bio-rd/bgp.go
+++ b/cmd/bio-rd/bgp.go
@@ -59,8 +59,12 @@ func (c *bgpConfigurator) reconfigureModifiedSessions(cfg *config.BGP) error {
 			}
 
 			if !oldCfg.NeedsRestart(newCfg) {
-				c.srv.ReplaceImportFilterChain(c.srv.GetDefaultVRF(), bn.PeerAddressIP, newCfg.IPv4.ImportFilterChain)
-				c.srv.ReplaceExportFilterChain(c.srv.GetDefaultVRF(), bn.PeerAddressIP, newCfg.IPv4.ExportFilterChain)
+				c.srv.ReplaceImportFilterChain(c.srv.GetDefaultVRF(),
+					bn.PeerAddressIP,
+					c.determineFilterChain(bg.ImportFilterChain, bn.ImportFilterChain))
+				c.srv.ReplaceExportFilterChain(c.srv.GetDefaultVRF(),
+					bn.PeerAddressIP,
+					c.determineFilterChain(bg.ExportFilterChain, bn.ExportFilterChain))
 				continue
 			}
 

--- a/cmd/bio-rd/config/bgp.go
+++ b/cmd/bio-rd/config/bgp.go
@@ -255,7 +255,7 @@ func (bn *BGPNeighbor) load(policyOptions *PolicyOptions) error {
 }
 
 type AddressFamilyConfig struct {
-	AddPath *AddPathConfig
+	AddPath *AddPathConfig `yaml:"add_path"`
 }
 
 type AddPathConfig struct {

--- a/cmd/bio-rd/config/bgp.go
+++ b/cmd/bio-rd/config/bgp.go
@@ -8,6 +8,10 @@ import (
 	"github.com/bio-routing/bio-rd/routingtable/filter"
 )
 
+const (
+	DefaultHoldTimeSeconds = 90
+)
+
 type BGP struct {
 	Groups []*BGPGroup `yaml:"groups"`
 }
@@ -58,7 +62,7 @@ func (bg *BGPGroup) load(localAS uint32, policyOptions *PolicyOptions) error {
 	}
 
 	if bg.HoldTime == 0 {
-		bg.HoldTime = 90
+		bg.HoldTime = DefaultHoldTimeSeconds
 	}
 
 	for i := range bg.Import {
@@ -118,6 +122,14 @@ func (bg *BGPGroup) load(localAS uint32, policyOptions *PolicyOptions) error {
 
 		if bn.HoldTime == 0 {
 			bn.HoldTime = bg.HoldTime
+		}
+
+		if bn.Multipath == nil {
+			bn.Multipath = bg.Multipath
+		}
+
+		if len(bn.RoutingInstance) == 0 {
+			bn.RoutingInstance = bg.RoutingInstance
 		}
 
 		err := bn.load(policyOptions)

--- a/cmd/bio-rd/config/bgp.go
+++ b/cmd/bio-rd/config/bgp.go
@@ -235,6 +235,7 @@ func (bn *BGPNeighbor) load(policyOptions *PolicyOptions) error {
 
 		bn.ExportFilterChain = append(bn.ExportFilterChain, f)
 	}
+
 	return nil
 }
 

--- a/cmd/bio-rd/config/bgp.go
+++ b/cmd/bio-rd/config/bgp.go
@@ -40,6 +40,7 @@ type BGPGroup struct {
 	RouteServerClient bool           `yaml:"route_server_client"`
 	Passive           bool           `yaml:"passive"`
 	Neighbors         []*BGPNeighbor `yaml:"neighbors"`
+	RoutingInstance   string         `yaml:"routing_instance"`
 }
 
 func (bg *BGPGroup) load(localAS uint32, policyOptions *PolicyOptions) error {
@@ -157,6 +158,7 @@ type BGPNeighbor struct {
 	IPv4                       *AddressFamilyConfig `yaml:"ipv4"`
 	IPv6                       *AddressFamilyConfig `yaml:"ipv6"`
 	AdvertiseIPv4MultiProtocol bool                 `yaml:"advertise_ipv4_multiprotocol"`
+	RoutingInstance            string               `yaml:"routing_instance"`
 }
 
 func (bn *BGPNeighbor) load(policyOptions *PolicyOptions) error {

--- a/cmd/bio-rd/config/bgp.go
+++ b/cmd/bio-rd/config/bgp.go
@@ -119,6 +119,7 @@ type BGPNeighbor struct {
 	PeerAddressIP     *bnet.IP
 	LocalAddress      string `yaml:"local_address"`
 	LocalAddressIP    *bnet.IP
+	Disabled          bool   `yaml:"disabled"`
 	TTL               uint8  `yaml:"ttl"`
 	AuthenticationKey string `yaml:"authentication_key"`
 	PeerAS            uint32 `yaml:"peer_as"`
@@ -134,7 +135,6 @@ type BGPNeighbor struct {
 	Passive           *bool  `yaml:"passive"`
 	ClusterID         string `yaml:"cluster_id"`
 	ClusterIDIP       *bnet.IP
-	AFIs              []*AFI `yaml:"afi"`
 }
 
 func (bn *BGPNeighbor) load(po *PolicyOptions) error {

--- a/cmd/bio-rd/config/bgp.go
+++ b/cmd/bio-rd/config/bgp.go
@@ -108,7 +108,7 @@ func (bg *BGPGroup) load(localAS uint32, policyOptions *PolicyOptions) error {
 		}
 
 		if bn.LocalAS == 0 {
-			bn.LocalAS = localAS
+			bn.LocalAS = bg.LocalAS
 		}
 
 		if bn.LocalAS == 0 {

--- a/cmd/bio-rd/config/bgp.go
+++ b/cmd/bio-rd/config/bgp.go
@@ -78,48 +78,48 @@ func (bg *BGPGroup) load(localAS uint32, policyOptions *PolicyOptions) error {
 		bg.ExportFilterChain = append(bg.ExportFilterChain, f)
 	}
 
-	for _, n := range bg.Neighbors {
-		if n.RouteServerClient == nil {
-			n.RouteServerClient = &bg.RouteServerClient
+	for _, bn := range bg.Neighbors {
+		if bn.RouteServerClient == nil {
+			bn.RouteServerClient = &bg.RouteServerClient
 		}
 
-		if n.Passive == nil {
-			n.Passive = &bg.Passive
+		if bn.Passive == nil {
+			bn.Passive = &bg.Passive
 		}
 
-		if n.LocalAddress == "" {
-			n.LocalAddressIP = bg.LocalAddressIP
+		if bn.LocalAddress == "" {
+			bn.LocalAddressIP = bg.LocalAddressIP
 		}
 
-		if n.TTL == 0 {
-			n.TTL = bg.TTL
+		if bn.TTL == 0 {
+			bn.TTL = bg.TTL
 		}
 
-		if n.AuthenticationKey == "" {
-			n.AuthenticationKey = bg.AuthenticationKey
+		if bn.AuthenticationKey == "" {
+			bn.AuthenticationKey = bg.AuthenticationKey
 		}
 
-		if n.LocalAS == 0 {
-			n.LocalAS = localAS
+		if bn.LocalAS == 0 {
+			bn.LocalAS = localAS
 		}
 
-		if n.LocalAS == 0 {
+		if bn.LocalAS == 0 {
 			return fmt.Errorf("local_as 0 is invalid")
 		}
 
-		if n.PeerAS == 0 {
-			n.PeerAS = bg.PeerAS
+		if bn.PeerAS == 0 {
+			bn.PeerAS = bg.PeerAS
 		}
 
-		if n.PeerAS == 0 {
+		if bn.PeerAS == 0 {
 			return fmt.Errorf("peer_as 0 is invalid")
 		}
 
-		if n.HoldTime == 0 {
-			n.HoldTime = bg.HoldTime
+		if bn.HoldTime == 0 {
+			bn.HoldTime = bg.HoldTime
 		}
 
-		err := n.load(policyOptions)
+		err := bn.load(policyOptions)
 		if err != nil {
 			return err
 		}
@@ -134,28 +134,29 @@ type Multipath struct {
 }
 
 type BGPNeighbor struct {
-	PeerAddress       string `yaml:"peer_address"`
-	PeerAddressIP     *bnet.IP
-	LocalAddress      string `yaml:"local_address"`
-	LocalAddressIP    *bnet.IP
-	Disabled          bool   `yaml:"disabled"`
-	TTL               uint8  `yaml:"ttl"`
-	AuthenticationKey string `yaml:"authentication_key"`
-	PeerAS            uint32 `yaml:"peer_as"`
-	LocalAS           uint32 `yaml:"local_as"`
-	HoldTime          uint16 `yaml:"hold_time"`
-	HoldTimeDuration  time.Duration
-	Multipath         *Multipath `yaml:"multipath"`
-	Import            []string   `yaml:"import"`
-	ImportFilterChain filter.Chain
-	Export            []string `yaml:"export"`
-	ExportFilterChain filter.Chain
-	RouteServerClient *bool  `yaml:"route_server_client"`
-	Passive           *bool  `yaml:"passive"`
-	ClusterID         string `yaml:"cluster_id"`
-	ClusterIDIP       *bnet.IP
-	IPv4              *AddressFamilyConfig
-	IPv6              *AddressFamilyConfig
+	PeerAddress                string `yaml:"peer_address"`
+	PeerAddressIP              *bnet.IP
+	LocalAddress               string `yaml:"local_address"`
+	LocalAddressIP             *bnet.IP
+	Disabled                   bool   `yaml:"disabled"`
+	TTL                        uint8  `yaml:"ttl"`
+	AuthenticationKey          string `yaml:"authentication_key"`
+	PeerAS                     uint32 `yaml:"peer_as"`
+	LocalAS                    uint32 `yaml:"local_as"`
+	HoldTime                   uint16 `yaml:"hold_time"`
+	HoldTimeDuration           time.Duration
+	Multipath                  *Multipath `yaml:"multipath"`
+	Import                     []string   `yaml:"import"`
+	ImportFilterChain          filter.Chain
+	Export                     []string `yaml:"export"`
+	ExportFilterChain          filter.Chain
+	RouteServerClient          *bool  `yaml:"route_server_client"`
+	Passive                    *bool  `yaml:"passive"`
+	ClusterID                  string `yaml:"cluster_id"`
+	ClusterIDIP                *bnet.IP
+	IPv4                       *AddressFamilyConfig `yaml:"ipv4"`
+	IPv6                       *AddressFamilyConfig `yaml:"ipv6"`
+	AdvertiseIPv4MultiProtocol bool                 `yaml:"advertise_ipv4_multiprotocol"`
 }
 
 func (bn *BGPNeighbor) load(policyOptions *PolicyOptions) error {

--- a/cmd/bio-rd/config/bgp_test.go
+++ b/cmd/bio-rd/config/bgp_test.go
@@ -30,6 +30,11 @@ groups:
     neighbors:
       - peer_address: 100.64.0.2
         cluster_id: 100.64.0.0
+        ipv4:
+          add_path:
+            receive: true
+            send:
+              path_count: 5
       - peer_address: 100.64.1.2
         local_address: 100.64.1.1
         local_as: 65400
@@ -43,6 +48,16 @@ groups:
         passive: false
         route_reflector_client: false
         route_server_client: false
+        ipv6:
+          add_path:
+            receive: true
+            send:
+              path_count: 2
+    ipv6:
+      add_path:
+        receive: false
+        send:
+          path_count: 10
   `
 )
 
@@ -87,6 +102,10 @@ func TestBGPLoad(t *testing.T) {
 	assert.Equal(t, filter.Chain{accept_all}, n1.ImportFilterChain, "neighbor 1 import")
 	assert.Equal(t, filter.Chain{reject_all}, n1.ExportFilterChain, "neighbor 1 export")
 	assert.Equal(t, bnet.IPv4FromOctets(100, 64, 0, 0).Dedup(), n1.ClusterIDIP, "neighbor 1 cluster ID")
+	assert.True(t, n1.IPv4.AddPath.Receive, "neighbor 1 IPv4 add path receive")
+	assert.False(t, n1.IPv6.AddPath.Receive, "neighbor 1 IPv6 add path receive")
+	assert.Equal(t, uint8(5), n1.IPv4.AddPath.Send.PathCount, "neighbor 1 IPv4 add path send count")
+	assert.Equal(t, uint8(10), n1.IPv6.AddPath.Send.PathCount, "neighbor 1 IPv6 add path send count")
 
 	n2 := group.Neighbors[1]
 	assert.Equal(t, bnet.IPv4FromOctets(100, 64, 1, 1).Dedup(), n2.LocalAddressIP, "neighbor 2 local address")
@@ -103,4 +122,7 @@ func TestBGPLoad(t *testing.T) {
 	assert.Equal(t, filter.Chain{reject_all}, n2.ImportFilterChain, "neighbor 2 import")
 	assert.Equal(t, filter.Chain{accept_all}, n2.ExportFilterChain, "neighbor 2 export")
 	assert.Nil(t, n2.ClusterIDIP, "neighbor 2 cluster ID")
+	assert.Nil(t, n2.IPv4, "neighbor 2 IPv4")
+	assert.True(t, n2.IPv6.AddPath.Receive, "neighbor 2 IPv6 add path receive")
+	assert.Equal(t, uint8(2), n2.IPv6.AddPath.Send.PathCount, "neighbor 2 IPv6 add path send count")
 }

--- a/cmd/bio-rd/config/bgp_test.go
+++ b/cmd/bio-rd/config/bgp_test.go
@@ -13,39 +13,40 @@ import (
 
 const (
 	BGPGroupTestFile = `
-name: Group1
-local_address: 100.64.0.1
-route_server_client: true
-route_reflector_client: true
-passive: true
-ttl: 10
-local_as: 65200
-peer_as: 65300
-authentication_key: secret
-hold_time: 180
-routing_instance: main
-import: ["ACCEPT_ALL"]
-export: ["REJECT_ALL"]
-neighbors:
-  - peer_address: 100.64.0.2
-    cluster_id: 100.64.0.0
-  - peer_address: 100.64.1.2
-    local_address: 100.64.1.1
-    local_as: 65400
-    peer_as: 65401
-    hold_time: 90
-    ttl: 1
-    routing_instance: test
-    export: ["ACCEPT_ALL"]
-    import: ["REJECT_ALL"]
-    authentication_key: top-secret
-    passive: false
-    route_reflector_client: false
-    route_server_client: false
+groups:
+  - name: Group1
+    local_address: 100.64.0.1
+    route_server_client: true
+    route_reflector_client: true
+    passive: true
+    ttl: 10
+    local_as: 65200
+    peer_as: 65300
+    authentication_key: secret
+    hold_time: 180
+    routing_instance: main
+    import: ["ACCEPT_ALL"]
+    export: ["REJECT_ALL"]
+    neighbors:
+      - peer_address: 100.64.0.2
+        cluster_id: 100.64.0.0
+      - peer_address: 100.64.1.2
+        local_address: 100.64.1.1
+        local_as: 65400
+        peer_as: 65401
+        hold_time: 90
+        ttl: 1
+        routing_instance: test
+        export: ["ACCEPT_ALL"]
+        import: ["REJECT_ALL"]
+        authentication_key: top-secret
+        passive: false
+        route_reflector_client: false
+        route_server_client: false
   `
 )
 
-func TestBGPGroupConfigInheritance(t *testing.T) {
+func TestBGPLoad(t *testing.T) {
 	policyOptions := &PolicyOptions{}
 	accept_all := filter.NewFilter("ACCEPT_ALL", nil)
 	reject_all := filter.NewFilter("REJECT_ALL", nil)
@@ -55,15 +56,18 @@ func TestBGPGroupConfigInheritance(t *testing.T) {
 	}
 
 	b := []byte(BGPGroupTestFile)
-	var group *BGPGroup
-	err := yaml.Unmarshal(b, &group)
+	var bgp *BGP
+	err := yaml.Unmarshal(b, &bgp)
 	if err != nil {
 		t.Fatalf("unexpected error while parsing: %s", err)
 	}
 
+	assert.Equal(t, 1, len(bgp.Groups), "group count")
+	group := bgp.Groups[0]
+
 	assert.Equal(t, 2, len(group.Neighbors), "neighbor count")
 
-	err = group.load(64900, policyOptions)
+	err = bgp.load(64900, policyOptions)
 	if err != nil {
 		t.Fatalf("unexpected error while loading group config: %s", err)
 	}

--- a/cmd/bio-rd/config/bgp_test.go
+++ b/cmd/bio-rd/config/bgp_test.go
@@ -30,6 +30,7 @@ groups:
     neighbors:
       - peer_address: 100.64.0.2
         cluster_id: 100.64.0.0
+        disabled: true
         ipv4:
           add_path:
             receive: true
@@ -106,6 +107,7 @@ func TestBGPLoad(t *testing.T) {
 	assert.False(t, n1.IPv6.AddPath.Receive, "neighbor 1 IPv6 add path receive")
 	assert.Equal(t, uint8(5), n1.IPv4.AddPath.Send.PathCount, "neighbor 1 IPv4 add path send count")
 	assert.Equal(t, uint8(10), n1.IPv6.AddPath.Send.PathCount, "neighbor 1 IPv6 add path send count")
+	assert.True(t, n1.Disabled, "neighbor 1 disabled")
 
 	n2 := group.Neighbors[1]
 	assert.Equal(t, bnet.IPv4FromOctets(100, 64, 1, 1).Dedup(), n2.LocalAddressIP, "neighbor 2 local address")

--- a/cmd/bio-rd/config/bgp_test.go
+++ b/cmd/bio-rd/config/bgp_test.go
@@ -27,6 +27,7 @@ groups:
     routing_instance: main
     import: ["ACCEPT_ALL"]
     export: ["REJECT_ALL"]
+    cluster_id: 100.65.1.1
     neighbors:
       - peer_address: 100.64.0.2
         cluster_id: 100.64.0.0
@@ -123,7 +124,7 @@ func TestBGPLoad(t *testing.T) {
 	assert.Equal(t, "test", n2.RoutingInstance, "neighbor 2 VRF")
 	assert.Equal(t, filter.Chain{reject_all}, n2.ImportFilterChain, "neighbor 2 import")
 	assert.Equal(t, filter.Chain{accept_all}, n2.ExportFilterChain, "neighbor 2 export")
-	assert.Nil(t, n2.ClusterIDIP, "neighbor 2 cluster ID")
+	assert.Equal(t, n2.ClusterIDIP, bnet.IPv4FromOctets(100, 65, 1, 1).Dedup(), "neighbor 2 cluster ID")
 	assert.Nil(t, n2.IPv4, "neighbor 2 IPv4")
 	assert.True(t, n2.IPv6.AddPath.Receive, "neighbor 2 IPv6 add path receive")
 	assert.Equal(t, uint8(2), n2.IPv6.AddPath.Send.PathCount, "neighbor 2 IPv6 add path send count")

--- a/cmd/bio-rd/config/bgp_test.go
+++ b/cmd/bio-rd/config/bgp_test.go
@@ -1,0 +1,102 @@
+package config
+
+import (
+	"testing"
+	"time"
+
+	bnet "github.com/bio-routing/bio-rd/net"
+	"github.com/bio-routing/bio-rd/routingtable/filter"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v2"
+)
+
+const (
+	BGPGroupTestFile = `
+name: Group1
+local_address: 100.64.0.1
+route_server_client: true
+route_reflector_client: true
+passive: true
+ttl: 10
+local_as: 65200
+peer_as: 65300
+authentication_key: secret
+hold_time: 180
+routing_instance: main
+import: ["ACCEPT_ALL"]
+export: ["REJECT_ALL"]
+neighbors:
+  - peer_address: 100.64.0.2
+    cluster_id: 100.64.0.0
+  - peer_address: 100.64.1.2
+    local_address: 100.64.1.1
+    local_as: 65400
+    peer_as: 65401
+    hold_time: 90
+    ttl: 1
+    routing_instance: test
+    export: ["ACCEPT_ALL"]
+    import: ["REJECT_ALL"]
+    authentication_key: top-secret
+    passive: false
+    route_reflector_client: false
+    route_server_client: false
+  `
+)
+
+func TestBGPGroupConfigInheritance(t *testing.T) {
+	policyOptions := &PolicyOptions{}
+	accept_all := filter.NewFilter("ACCEPT_ALL", nil)
+	reject_all := filter.NewFilter("REJECT_ALL", nil)
+	policyOptions.PolicyStatementsFilter = []*filter.Filter{
+		accept_all,
+		reject_all,
+	}
+
+	b := []byte(BGPGroupTestFile)
+	var group *BGPGroup
+	err := yaml.Unmarshal(b, &group)
+	if err != nil {
+		t.Fatalf("unexpected error while parsing: %s", err)
+	}
+
+	assert.Equal(t, 2, len(group.Neighbors), "neighbor count")
+
+	err = group.load(64900, policyOptions)
+	if err != nil {
+		t.Fatalf("unexpected error while loading group config: %s", err)
+	}
+
+	n1 := group.Neighbors[0]
+	assert.Equal(t, bnet.IPv4FromOctets(100, 64, 0, 1).Dedup(), n1.LocalAddressIP, "neighbor 1 local address")
+	assert.Equal(t, bnet.IPv4FromOctets(100, 64, 0, 2).Dedup(), n1.PeerAddressIP, "neighbor 1 peer address")
+	assert.True(t, *n1.RouteServerClient, "neighbor 1 route server client")
+	assert.True(t, *n1.RouteReflectorClient, "neighbor 1 route reflector client")
+	assert.True(t, *n1.Passive, "neighbor 1 passive")
+	assert.Equal(t, uint8(10), n1.TTL, "neighbor 1 TTL")
+	assert.Equal(t, uint32(65200), n1.LocalAS, "neighbor 1 local ASN")
+	assert.Equal(t, uint32(65300), n1.PeerAS, "neighbor 1 peer ASN")
+	assert.Equal(t, "secret", n1.AuthenticationKey, "neighbor 1 auth")
+	assert.Equal(t, 180*time.Second, n1.HoldTimeDuration, "neighbor 1 hold")
+	assert.Equal(t, "main", n1.RoutingInstance, "neighbor 1 VRF")
+	assert.Equal(t, filter.Chain{accept_all}, n1.ImportFilterChain, "neighbor 1 import")
+	assert.Equal(t, filter.Chain{reject_all}, n1.ExportFilterChain, "neighbor 1 export")
+	assert.Equal(t, bnet.IPv4FromOctets(100, 64, 0, 0).Dedup(), n1.ClusterIDIP, "neighbor 1 cluster ID")
+
+	n2 := group.Neighbors[1]
+	assert.Equal(t, bnet.IPv4FromOctets(100, 64, 1, 1).Dedup(), n2.LocalAddressIP, "neighbor 2 local address")
+	assert.Equal(t, bnet.IPv4FromOctets(100, 64, 1, 2).Dedup(), n2.PeerAddressIP, "neighbor 2 peer address")
+	assert.False(t, *n2.RouteServerClient, "neighbor 2 route server client")
+	assert.False(t, *n2.RouteReflectorClient, "neighbor 2 route reflector client")
+	assert.False(t, *n2.Passive, "neighbor 2 passive")
+	assert.Equal(t, uint8(1), n2.TTL, "neighbor 2 TTL")
+	assert.Equal(t, uint32(65400), n2.LocalAS, "neighbor 2 local ASN")
+	assert.Equal(t, uint32(65401), n2.PeerAS, "neighbor 2 peer ASN")
+	assert.Equal(t, "top-secret", n2.AuthenticationKey, "neighbor 2 auth")
+	assert.Equal(t, 90*time.Second, n2.HoldTimeDuration, "neighbor 2 hold")
+	assert.Equal(t, "test", n2.RoutingInstance, "neighbor 2 VRF")
+	assert.Equal(t, filter.Chain{reject_all}, n2.ImportFilterChain, "neighbor 2 import")
+	assert.Equal(t, filter.Chain{accept_all}, n2.ExportFilterChain, "neighbor 2 export")
+	assert.Nil(t, n2.ClusterIDIP, "neighbor 2 cluster ID")
+}

--- a/cmd/bio-rd/main.go
+++ b/cmd/bio-rd/main.go
@@ -148,7 +148,10 @@ func loadConfig(cfg *config.Config) error {
 
 	if cfg.Protocols != nil {
 		if cfg.Protocols.BGP != nil {
-			err := configureProtocolsBGP(cfg.Protocols.BGP)
+			bgpCfgtr := &bgpConfigurator{
+				srv: bgpSrv,
+			}
+			err := bgpCfgtr.configure(cfg.Protocols.BGP)
 			if err != nil {
 				return fmt.Errorf("unable to configure BGP: %w", err)
 			}

--- a/cmd/bio-rd/main.go
+++ b/cmd/bio-rd/main.go
@@ -149,7 +149,8 @@ func loadConfig(cfg *config.Config) error {
 	if cfg.Protocols != nil {
 		if cfg.Protocols.BGP != nil {
 			bgpCfgtr := &bgpConfigurator{
-				srv: bgpSrv,
+				srv:    bgpSrv,
+				vrfReg: vrfReg,
 			}
 			err := bgpCfgtr.configure(cfg.Protocols.BGP)
 			if err != nil {

--- a/docker/bio-rd/Dockerfile
+++ b/docker/bio-rd/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang as builder
+ADD . /go/bio
+WORKDIR /go/bio/cmd/bio-rd
+RUN GOOS=linux go build -o /go/bin/bio-rd
+
+FROM debian:stable
+WORKDIR /app
+ENV CMD_ARGS="--config.file=/config/bio-rd.yml"
+COPY --from=builder /go/bin/bio-rd .
+CMD /app/bio-rd ${CMD_ARGS}
+VOLUME /config
+EXPOSE 179
+EXPOSE 5566
+EXPOSE 55667

--- a/docker/bio-rd/Dockerfile
+++ b/docker/bio-rd/Dockerfile
@@ -1,13 +1,17 @@
 FROM golang as builder
-ADD . /go/bio
-WORKDIR /go/bio/cmd/bio-rd
+ADD . /go/bio-rd
+WORKDIR /go/bio-rd/cmd/bio-rd
 RUN GOOS=linux go build -o /go/bin/bio-rd
 
 FROM debian:stable
 WORKDIR /app
-ENV CMD_ARGS="--config.file=/config/bio-rd.yml"
 COPY --from=builder /go/bin/bio-rd .
-CMD /app/bio-rd ${CMD_ARGS}
+CMD /app/bio-rd --config.file=/config/bio-rd.yml ${CMD_ARGS}
+#RUN apt update && \
+#    apt install -y libcap2-bin && \
+#    setcap cap_net_raw,cap_net_admin,cap_net_bind_service+eip /app/bio-rd && \
+#    useradd --system bio-rd
+#USER bio-rd
 VOLUME /config
 EXPOSE 179
 EXPOSE 5566

--- a/docker/bio-rd/Dockerfile
+++ b/docker/bio-rd/Dockerfile
@@ -7,11 +7,11 @@ FROM debian:stable
 WORKDIR /app
 COPY --from=builder /go/bin/bio-rd .
 CMD /app/bio-rd --config.file=/config/bio-rd.yml ${CMD_ARGS}
-#RUN apt update && \
-#    apt install -y libcap2-bin && \
-#    setcap cap_net_raw,cap_net_admin,cap_net_bind_service+eip /app/bio-rd && \
-#    useradd --system bio-rd
-#USER bio-rd
+RUN apt update && \
+   apt install -y libcap2-bin && \
+   setcap cap_net_bind_service+eip /app/bio-rd && \
+   useradd --system bio-rd
+USER bio-rd
 VOLUME /config
 EXPOSE 179
 EXPOSE 5566


### PR DESCRIPTION
This PR tries to improve the bio-rd BGP configuration.
It aims to provide the basic capability to run bio-rd in the current state after checking out supporting most out of the current feature set.

This is work in progress and thus only a draft for now.

In detail:
* adds IPv6 support
* improve readability
* encapsulate BGP server configuration
* allow to change BGP listen address
* respect configured VRF
* add group / neighbor inheritance for AFI specific configurations
* add tests for BGP config loading