### PR TITLE
Lower the bar on building Bio-Routing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
         run: .github/check-gofmt.sh
 
       - name: Test
-        run: go test -v -cover -coverprofile=coverage.txt ./...
+        run: make test-coverage
 
       # Upload Coverage Report
       - name: Upload coverage to Codecov
@@ -31,5 +31,5 @@ jobs:
           name: codecov-${{ matrix.platform }}-${{ matrix.go-version }}
           fail_ci_if_error: true
 
-      - name: Build examples
-        run: scripts/build_examples.sh
+      - name: Build commands and examples
+        run: make build

--- a/.gitignore
+++ b/.gitignore
@@ -23,10 +23,8 @@ coverage.txt
 /cmd/bio-rdc/bio-rdc
 /cmd/ris-mirror/ris-mirror
 /cmd/ris/ris
+/cmd/ris-lg/ris-lg
 /cmd/riscli/riscli
 /examples/bgp/bgp
 /examples/bmp/bmp
 /examples/kernel
-
-# bazel directories
-/bazel-*

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+#!/usr/bin/make
+#
+# Bio-Routing Makefile
+#
+# Maximilian Wilhelm <max@sdn.clinic>
+#  --  Tue 02 Jan 2024 08:21:17 PM CET
+#
+
+expand_binary = $(dir)/$(notdir $(dir))
+
+CMD_DIRS := $(wildcard cmd/*)
+CMDS := $(foreach dir, $(CMD_DIRS), $(expand_binary))
+EXAMPLE_DIRS = $(wildcard examples/*)
+EXAMPLES := $(foreach dir, $(EXAMPLE_DIRS), $(expand_binary))
+
+%:
+	cd $(dir $(@)) && go build
+
+
+build: $(CMDS) $(EXAMPLES)
+
+all: clean build test
+
+clean:
+	rm -f -- $(CMDS) $(EXMAPLES)
+
+test:
+	@echo "Running tests..."
+	go test ./...
+
+test-coverage:
+	go test -v -cover -coverprofile=coverage.txt ./...
+
+.PHONY: all build clean test test-coverage

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# bio-rd
+# Bio-Routing
 
 A re-implementation of BGP, IS-IS and OSPF in go. We value respect and robustness!
 
@@ -9,18 +9,28 @@ A re-implementation of BGP, IS-IS and OSPF in go. We value respect and robustnes
 
 ## Building
 
-### Build the examples
+To build Bio-Routing binares and/or examples you need Go installed and in your `$PATH`.
+Currently the minimum supported Go version is v1.20.
 
-#### BGP
-
+To build all commands and examples, you can leverage the `Makefile`, if you have `make` installed, and run
 ```bash
-cd examples/bgp/ && go build
+make build
 ```
 
-#### BMP
+If you're only interested in one particular command/service or example, found in the `cmd/` or `examples/` sub-directories within this repository,
+enter the respective directory on a shell and run `go build`.
+You should get a binary named like the current directory, which you can run.
 
+To build the BGP examples, this would look like
 ```bash
-cd examples/bmp/ && go build
+cd exmaples/bgp
+go build
+```
+
+To build the `bio-rd` service binary, this would look like
+```bash
+cd cmd/bio-rd
+go build
 ```
 
 ### Run Tests
@@ -29,10 +39,31 @@ cd examples/bmp/ && go build
 go test -v -cover ./...
 ```
 
-### Update modules
+## Running bio-rd
+
+`bio-rd` is the main binary which provides a configurable BGP speaker.
+It supports the following command-line parameters:
+
+    Usage of ./bio-rd:
+      -bgp.listen-addr-ipv4 string
+        	BGP listen address for IPv4 AFI (default "0.0.0.0:179")
+      -bgp.listen-addr-ipv6 string
+        	BGP listen address for IPv6 AFI (default "[::]:179")
+      -config.file string
+        	bio-rd config file (default "bio-rd.yml")
+      -grpc_keepalive_min_time uint
+        	Minimum time (seconds) for a client to wait between GRPC keepalive pings (default 1)
+      -grpc_port uint
+        	GRPC API server port (default 5566)
+      -metrics_port uint
+        	Metrics HTTP server port (default 55667)
+
+You can find an [example configuration file](cmd/bio-rd/bio-rd.yml) within in `cmd/bio-rd` directory.
+
+As `bio-rd` needs to listen on the priviledged TCP port 179 for BGP connections, you either need to start the service as `root` or using `sudo`, e.g.
 
 ```bash
-go mod tidy
+$ sudo ./bio-rd -config.file bio-rd.yml
 ```
 
 ## Benchmarks

--- a/cmd/bio-rd/bio-rd.yml
+++ b/cmd/bio-rd/bio-rd.yml
@@ -77,15 +77,3 @@ protocols:
             peer_as: 65300
             import: ["PeerB-In"]
             export: ["ACCEPT_ALL"]
-  isis:
-    NETs: ["49.0001.0100.0000.0002.00"]
-    level1:
-      disable: true
-    interfaces:
-      - name: "tap0"
-        level2:
-          metric: 10
-      - name: "lo"
-        passive: true
-        level2:
-          metric: 0

--- a/scripts/build_examples.sh
+++ b/scripts/build_examples.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-for i in examples/*; do
-  echo "building $i"
-  go install "github.com/bio-routing/bio-rd/$i"
-done


### PR DESCRIPTION
This is intended as the first step to lower the bar of entry on using Bio-Routing :-)

* Add a `Makefile` to build Bio-Routing commands and examples & test the code
* Update GitHub workflows to use make targets
* Update README to point out how to build and run `bio-rd`
* Some clean-ups

A good next step would be to start populating `Documentation/user` a bit more on more example configurations and how to use `bio-rd` and `bio-rdc` together.