### PR TITLE
Enable SO_REUSEPORT

### DIFF
--- a/net/tcp/listen.go
+++ b/net/tcp/listen.go
@@ -60,6 +60,12 @@ func (lf *ListenerFactory) NewListener(v *vrf.VRF, laddr *net.TCPAddr, ttl uint8
 		return nil, fmt.Errorf("unable to get SO_REUSEADDR %w", err)
 	}
 
+	err = unix.SetsockoptInt(fd, unix.SOL_SOCKET, unix.SO_REUSEPORT, 1)
+	if err != nil {
+		unix.Close(fd)
+		return nil, fmt.Errorf("unable to get SO_REUSEPORT %w", err)
+	}
+
 	if ttl != 0 {
 		err = unix.SetsockoptInt(fd, SOL_IP, unix.IP_TTL, int(ttl))
 		if err != nil {

--- a/net/tcp/listener_manager.go
+++ b/net/tcp/listener_manager.go
@@ -27,14 +27,16 @@ type ListenerManager struct {
 	listenersByVRFmu sync.RWMutex
 	acceptCh         chan ConnWithVRF
 	listenerFactory  ListenerFactoryI
+	reusePort        bool
 }
 
-func NewListenerManager(listenAddrsByVRF map[string][]string) *ListenerManager {
+func NewListenerManager(listenAddrsByVRF map[string][]string, reusePort bool) *ListenerManager {
 	return &ListenerManager{
 		listenAddrsByVRF: listenAddrsByVRF,
 		listenersByVRF:   make(map[string][]ListenerI),
 		listenerFactory:  NewListenerFactory(),
 		acceptCh:         make(chan ConnWithVRF),
+		reusePort:        reusePort,
 	}
 }
 
@@ -93,7 +95,7 @@ func (lm *ListenerManager) _addListener(vrf *vrf.VRF, addr string, ch chan ConnW
 	}
 
 	log.Infof("Listener manager: Starting TCP listener on %s in VRF %s", addr, vrf.Name())
-	l, err := lm.listenerFactory.NewListener(vrf, tcpaddr, 255)
+	l, err := lm.listenerFactory.NewListener(vrf, tcpaddr, 255, lm.reusePort)
 	if err != nil {
 		return err
 	}

--- a/protocols/bgp/server/server.go
+++ b/protocols/bgp/server/server.go
@@ -29,6 +29,7 @@ type BGPServerConfig struct {
 
 	// Optional attributes
 	DefaultLocalPreference *uint32
+	ReusePort              bool
 }
 
 type bgpServer struct {
@@ -68,7 +69,7 @@ func newBGPServer(config BGPServerConfig) *bgpServer {
 	server := &bgpServer{
 		config:          config,
 		peers:           newPeerManager(),
-		listenerManager: tcp.NewListenerManager(config.ListenAddrsByVRF),
+		listenerManager: tcp.NewListenerManager(config.ListenAddrsByVRF, config.ReusePort),
 	}
 
 	server.metrics = &metricsService{server}

--- a/tests/bgp_integration_test.go
+++ b/tests/bgp_integration_test.go
@@ -28,7 +28,7 @@ func TestBGP(t *testing.T) {
 		"main": {
 			"0.0.0.0:179",
 		},
-	})
+	}, false)
 
 	lm.SetListenerFactory(tcp.NewMockListenerFactory())
 	b.SetListenerManager(lm)


### PR DESCRIPTION
Enable SO_REUSEPORT on the TCP socket,

This enables multiple instances of the BGP server to be started on the same machine, binding to the same TCP port.

The kernel will load-balance the incoming connections to all listening instances.
Instances that have the correct BGP peers configured will take the connection,
and those who don't will reject it, letting another instance have a try when the router restarts the connection.