### PR TITLE
Update bgp_path_cache.go

### DIFF
--- a/route/bgp_path_cache.go
+++ b/route/bgp_path_cache.go
@@ -31,7 +31,8 @@ func (bgpc *bgpPathACache) get(p *BGPPathA) *BGPPathA {
 		return x
 	}
 
-	bgpc.cache[*p] = p
+        bgpc.cache[p] = p
+
 	bgpc.cacheMu.Unlock()
 	return p
 }


### PR DESCRIPTION
o fix this, you should modify the way you are adding entries to the cache. Instead of duplicating the BGPPathA instances, you can store a pointer to the existing instance.