### PR TITLE
Fix OPEN message tests wrt RFC6286 & update to Go 1.23

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.22.x]
+        go-version: [1.23.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/cmd/bio-rd/main.go
+++ b/cmd/bio-rd/main.go
@@ -69,8 +69,8 @@ func main() {
 
 	listenAddrsByVRF := map[string][]string{
 		vrf.DefaultVRFName: {
-			fmt.Sprintf(*bgpListenAddrIPv6),
-			fmt.Sprintf(*bgpListenAddrIPv4),
+			*bgpListenAddrIPv6,
+			*bgpListenAddrIPv4,
 		},
 	}
 

--- a/fuzzing/packet/gen_initial_corpus.go
+++ b/fuzzing/packet/gen_initial_corpus.go
@@ -99,11 +99,13 @@ func main() {
 			wantFail: true,
 		},
 	}
+
 	for i, t := range tests {
 		f, err := os.Create(fmt.Sprintf("corpus/%v.bytes", i))
 		if err != nil {
-			log.Fatalf(err.Error())
+			log.Fatalf("%s", err.Error())
 		}
+
 		f.Write(t.input)
 		f.Close()
 	}

--- a/go.mod
+++ b/go.mod
@@ -41,4 +41,6 @@ require (
 	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1 // indirect
 )
 
-go 1.18
+go 1.23.0
+
+toolchain go1.24.2

--- a/go.sum
+++ b/go.sum
@@ -51,6 +51,7 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0 h1:Iju5GlWwrvL6UBg4zJJt3btmonfrMlCDdsejg4CZE7c=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
@@ -133,6 +134,7 @@ github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc/go.mod h1:ZjcWmF
 go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/goleak v1.1.11 h1:wy28qYRKZgnJTxGxvye5/wgWr1EKjmUDGYox5mGlRlI=
+go.uber.org/goleak v1.1.11/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 go.uber.org/multierr v1.6.0 h1:y6IPFStTAIT5Ytl7/XYmHvzXQ7S3g/IeZW9hyZ5thw4=
 go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
 go.uber.org/zap v1.24.0 h1:FiJd5l1UOLj0wCgbSE0rwwXHzEdAZS6hiiSnxJN/D60=

--- a/protocols/bgp/packet/decoder.go
+++ b/protocols/bgp/packet/decoder.go
@@ -356,6 +356,14 @@ func validateOpen(msg *BGPOpen) error {
 		}
 	}
 
+	if msg.BGPIdentifier == 0 {
+		return BGPError{
+			ErrorCode:    OpenMessageError,
+			ErrorSubCode: BadBGPIdentifier,
+			ErrorStr:     "BGP Identifier must not be zero",
+		}
+	}
+
 	return nil
 }
 

--- a/protocols/bgp/packet/decoder_test.go
+++ b/protocols/bgp/packet/decoder_test.go
@@ -1428,10 +1428,18 @@ func TestValidateOpenMessage(t *testing.T) {
 			wantFail: false,
 		},
 		{
-			name: "Invalid Identifier",
+			name: "Invalid version",
+			input: &BGPOpen{
+				Version:       3,
+				BGPIdentifier: convert.Uint32b([]byte{8, 8, 8, 8}),
+			},
+			wantFail: true,
+		},
+		{
+			name: "Invalid identifier",
 			input: &BGPOpen{
 				Version:       4,
-				BGPIdentifier: convert.Uint32b([]byte{0, 8, 8, 8}),
+				BGPIdentifier: 0,
 			},
 			wantFail: true,
 		},
@@ -1440,16 +1448,10 @@ func TestValidateOpenMessage(t *testing.T) {
 	for _, test := range tests {
 		res := validateOpen(test.input)
 
-		if res != nil {
-			if test.wantFail {
-				continue
-			}
-			t.Errorf("Unexpected failure for test %q: %v", test.name, res)
-			continue
-		}
-
 		if test.wantFail {
-			t.Errorf("Unexpected success for test %q", test.name)
+			assert.Error(t, res)
+		} else {
+			assert.NoError(t, res)
 		}
 	}
 }

--- a/protocols/bgp/server/fsm_open_sent.go
+++ b/protocols/bgp/server/fsm_open_sent.go
@@ -127,7 +127,8 @@ func (s *openSentState) openMsgReceived(openMsg *packet.BGPOpen) (state, string)
 	// RFC6286, Sect 2.2: If the BGP Identifier field of the OPEN message is zero,
 	// or if it is the same as the BGP Identifier of the local BGP speaker and the
 	// message is from an internal peer, then the Error Subcode is set to "Bad BGP Identifier".
-	if openMsg.BGPIdentifier == 0 || (s.fsm.peer.localASN == s.fsm.peer.peerASN && s.fsm.peer.routerID == openMsg.BGPIdentifier) {
+	// A zero BGP identifier is already checked when decoding the OPEN message.
+	if s.fsm.peer.localASN == s.fsm.peer.peerASN && s.fsm.peer.routerID == openMsg.BGPIdentifier {
 		s.fsm.sendNotification(packet.OpenMessageError, packet.BadBGPIdentifier)
 		return newIdleState(s.fsm), fmt.Sprintf("Bad BGP Identifier %d", openMsg.BGPIdentifier)
 	}

--- a/protocols/bgp/server/update_sender.go
+++ b/protocols/bgp/server/update_sender.go
@@ -338,7 +338,7 @@ func (u *UpdateSender) withdrawPrefix(out io.Writer, pfx *bnet.Prefix, p *route.
 	}
 
 	if !u.addressFamily.multiProtocol {
-		return fmt.Errorf(packet.AFIName(u.addressFamily.afi) + " was not negotiated")
+		return fmt.Errorf("%s was not negotiated", packet.AFIName(u.addressFamily.afi))
 	}
 
 	return u.withdrawPrefixMultiProtocol(out, pfx, p)


### PR DESCRIPTION
Moved checkes for zero BGP identifier into OPEN message validation function and updated tests accordingly.

Also update to Go 1.23, as required by included packages.