### PR TITLE
fix: avoid internal errors on query parsing for ris-lg

### DIFF
--- a/cmd/ris-lg/lg/lg.go
+++ b/cmd/ris-lg/lg/lg.go
@@ -166,13 +166,13 @@ func (l *LookingGlass) Routes(w http.ResponseWriter, r *http.Request) {
 
 	originASN, err := getOriginASN(r)
 	if err != nil {
-		writeAndLogError(w, http.StatusInternalServerError, fmt.Sprintf("unable to get origin_asn: %v", err))
+		writeAndLogError(w, http.StatusBadRequest, fmt.Sprintf("unable to get origin_asn: %v", err))
 		return
 	}
 
 	afi, err := getAFI(r)
 	if err != nil {
-		writeAndLogError(w, http.StatusInternalServerError, fmt.Sprintf("unable to get afi: %v", err))
+		writeAndLogError(w, http.StatusBadRequest, fmt.Sprintf("unable to get afi: %v", err))
 		return
 	}
 


### PR DESCRIPTION
Hey 👋 

In ris-lg, if the client is sending an origin ASN or AFI which cannot be converted from string to int with Atoi, it receives a 500 internal error. I believe It would be more meaningful to serve a 400 Bad Request instead. 