### PR TITLE
fix: prevent nil dereference in Path.ECMP() and BGPPath.Prepend()

### DIFF
--- a/route/bgp_path.go
+++ b/route/bgp_path.go
@@ -652,6 +652,10 @@ func (b *BGPPath) Prepend(asn uint32, times uint16) {
 		return
 	}
 
+	if b.ASPath == nil {
+		b.ASPath = types.NewASPath(nil)
+	}
+
 	if len(*b.ASPath) == 0 {
 		b.insertNewASSequence()
 	}

--- a/route/mixed_path_type_test.go
+++ b/route/mixed_path_type_test.go
@@ -1,0 +1,173 @@
+package route
+
+import (
+	"testing"
+
+	bnet "github.com/bio-routing/bio-rd/net"
+	"github.com/bio-routing/bio-rd/protocols/bgp/types"
+)
+
+// TestECMP_MixedPathTypes_BGPvsStatic verifies that ECMP does not panic
+// when comparing a BGPPathType path against a StaticPathType path.
+// This is the primary crash: bio-rd calls p.BGPPath.ECMP(q.BGPPath)
+// without checking that q is also BGPPathType. When q is StaticPathType,
+// q.BGPPath is nil → nil pointer dereference.
+func TestECMP_MixedPathTypes_BGPvsStatic(t *testing.T) {
+	bgpPath := &Path{
+		Type: BGPPathType,
+		BGPPath: &BGPPath{
+			BGPPathA: &BGPPathA{
+				NextHop:   bnet.IPv4(1).Ptr(),
+				LocalPref: 100,
+				Origin:    0,
+				Source:    bnet.IPv4(1).Ptr(),
+			},
+			ASPath:    types.NewASPath([]uint32{64512}),
+			ASPathLen: 1,
+		},
+	}
+
+	staticPath := &Path{
+		Type: StaticPathType,
+		StaticPath: &StaticPath{
+			NextHop: bnet.IPv4(2).Ptr(),
+		},
+	}
+
+	// Must not panic — should return false (different types are never ECMP-equal)
+	result := bgpPath.ECMP(staticPath)
+	if result {
+		t.Error("ECMP should return false for different path types")
+	}
+}
+
+// TestECMP_MixedPathTypes_StaticvsBGP is the reverse direction.
+func TestECMP_MixedPathTypes_StaticvsBGP(t *testing.T) {
+	staticPath := &Path{
+		Type: StaticPathType,
+		StaticPath: &StaticPath{
+			NextHop: bnet.IPv4(1).Ptr(),
+		},
+	}
+
+	bgpPath := &Path{
+		Type: BGPPathType,
+		BGPPath: &BGPPath{
+			BGPPathA: &BGPPathA{
+				NextHop:   bnet.IPv4(2).Ptr(),
+				LocalPref: 100,
+				Origin:    0,
+				Source:    bnet.IPv4(2).Ptr(),
+			},
+			ASPath:    types.NewASPath([]uint32{64513}),
+			ASPathLen: 1,
+		},
+	}
+
+	result := staticPath.ECMP(bgpPath)
+	if result {
+		t.Error("ECMP should return false for different path types")
+	}
+}
+
+// TestECMP_MixedPathTypes_FIBvsBGP covers the FIBPathType case.
+func TestECMP_MixedPathTypes_FIBvsBGP(t *testing.T) {
+	fibPath := &Path{
+		Type: FIBPathType,
+		FIBPath: &FIBPath{
+			NextHop: bnet.IPv4(1).Ptr(),
+		},
+	}
+
+	bgpPath := &Path{
+		Type: BGPPathType,
+		BGPPath: &BGPPath{
+			BGPPathA: &BGPPathA{
+				NextHop:   bnet.IPv4(2).Ptr(),
+				LocalPref: 100,
+				Origin:    0,
+				Source:    bnet.IPv4(2).Ptr(),
+			},
+			ASPath:    types.NewASPath([]uint32{64512}),
+			ASPathLen: 1,
+		},
+	}
+
+	result := fibPath.ECMP(bgpPath)
+	if result {
+		t.Error("ECMP should return false for different path types")
+	}
+}
+
+// TestRouteUpdateEqualPathCount_MixedTypes verifies that
+// Route.updateEqualPathCount does not panic when the route has paths
+// of different types (the real-world scenario: locally-originated
+// StaticPath + BGP-learned BGPPath for the same anycast prefix).
+func TestRouteUpdateEqualPathCount_MixedTypes(t *testing.T) {
+	pfx := bnet.NewPfx(bnet.IPv4FromOctets(10, 0, 99, 0), 24)
+
+	r := NewRoute(pfx.Ptr(), &Path{
+		Type: StaticPathType,
+		StaticPath: &StaticPath{
+			NextHop: bnet.IPv4(1).Ptr(),
+		},
+	})
+
+	r.AddPath(&Path{
+		Type: BGPPathType,
+		BGPPath: &BGPPath{
+			BGPPathA: &BGPPathA{
+				NextHop:   bnet.IPv4(2).Ptr(),
+				LocalPref: 100,
+				Origin:    0,
+				Source:    bnet.IPv4(2).Ptr(),
+			},
+			ASPath:    types.NewASPath([]uint32{64513}),
+			ASPathLen: 1,
+		},
+	})
+
+	// Trigger path selection, which in turn calls updateEqualPathCount.
+	r.PathSelection()
+
+	// Must not panic and should result in a single ECMP path (static preferred).
+	count := r.ECMPPathCount()
+	if count != 1 {
+		t.Errorf("unexpected ECMP count: got %d, want 1", count)
+	}
+}
+
+// TestBGPPathPrepend_NilASPath verifies that Prepend does not panic
+// when ASPath is nil. This happens when a route is originated locally
+// as BGPPathType without initializing the ASPath field.
+func TestBGPPathPrepend_NilASPath(t *testing.T) {
+	p := &BGPPath{
+		BGPPathA: &BGPPathA{
+			NextHop:   bnet.IPv4(1).Ptr(),
+			LocalPref: 200,
+			Origin:    0,
+			Source:    bnet.IPv4(1).Ptr(),
+		},
+		ASPath: nil, // not initialized
+	}
+
+	// Must not panic — should handle nil ASPath gracefully
+	p.Prepend(64512, 1)
+
+	if p.ASPath == nil {
+		t.Error("Prepend should initialize ASPath if nil")
+	}
+	if p.ASPathLen == 0 {
+		t.Error("Prepend should increase ASPathLen")
+	}
+	if len(*p.ASPath) == 0 {
+		t.Error("Prepend should add at least one AS_PATH segment")
+		return
+	}
+	firstSeg := (*p.ASPath)[0]
+	if len(firstSeg.ASNs) == 0 {
+		t.Error("Prepend should add at least one ASN to the first AS_PATH segment")
+	} else if firstSeg.ASNs[0] != 64512 {
+		t.Errorf("Prepend should add prepended ASN 64512, got %d", firstSeg.ASNs[0])
+	}
+}

--- a/route/path.go
+++ b/route/path.go
@@ -65,6 +65,10 @@ func (p *Path) Select(q *Path) int8 {
 
 // ECMP checks if path p and q are equal enough to be considered for ECMP usage
 func (p *Path) ECMP(q *Path) bool {
+	if p.Type != q.Type {
+		return false
+	}
+
 	switch p.Type {
 	case BGPPathType:
 		return p.BGPPath.ECMP(q.BGPPath)


### PR DESCRIPTION
Hi! We're using bio-rd as an embedded BGP speaker in a project. We ran into a crash in testing that we think may be a bug in `Path.ECMP()` — wanted to share our findings and a proposed fix.

### How we found it

We have a scenario where two nodes each originate the same anycast prefix (`10.0.99.0/24`) as a `StaticPathType` route via `LocRIB.AddPath()`. When the two nodes peer over eBGP, each receives the other's copy of that prefix as a `BGPPathType` route. At that point the locRIB has two paths for the same prefix — one static, one BGP — and the process panics:

```
panic: runtime error: invalid memory address or nil pointer dereference

goroutine 144 [running]:
github.com/bio-routing/bio-rd/route.(*BGPPath).ECMP(...)
    route/bgp_path.go:229
github.com/bio-routing/bio-rd/route.(*Path).ECMP(...)
    route/path.go:70
github.com/bio-routing/bio-rd/route.(*Route).updateEqualPathCount(...)
    route/route.go:318
github.com/bio-routing/bio-rd/route.(*Route).PathSelection(...)
    route/route.go:210
github.com/bio-routing/bio-rd/routingtable/locRIB.(*LocRIB).AddPath(...)
```

Since this happens inside the FSM goroutine, we can't `recover()` from it — it kills the process.

### What we think is happening

`Path.ECMP()` (`route/path.go:67-78`) switches on `p.Type` and calls the type-specific ECMP method on both `p` and `q`, but doesn't check that `q` has the same type first:

```go
func (p *Path) ECMP(q *Path) bool {
    switch p.Type {
    case BGPPathType:
        return p.BGPPath.ECMP(q.BGPPath)  // q.BGPPath is nil if q is StaticPathType
```

We noticed that `Path.Select()` in the same file already has the guard:

```go
func (p *Path) Select(q *Path) int8 {
    if p.Type > q.Type {
        return 1
    }
    if p.Type < q.Type {
        return -1
    }
    // ... switch on p.Type ...
```

So it looks like `ECMP()` may have been missed when that guard was added to `Select()`.

We also noticed that `AdjRIBOut.redistributePath()` explicitly handles redistribution from `StaticPathType` to BGP, which suggests mixed path types in the same RIB is an intended use case.

### Second issue: BGPPath.Prepend() with nil ASPath

While investigating, we also hit a related panic in `BGPPath.Prepend()` (`route/bgp_path.go:655`):

```go
if len(*b.ASPath) == 0 {  // panics if b.ASPath is nil
```

This happens when a `BGPPath` is constructed without initializing `ASPath` — `Prepend()` is then called during the export pipeline and dereferences the nil pointer. A nil check before the existing length check would make this defensive.

### What this PR does

- `Path.ECMP()`: adds `if p.Type != q.Type { return false }` before the switch (mirrors the existing guard in `Select()`)
- `BGPPath.Prepend()`: initializes `ASPath` via `types.NewASPath(nil)` if nil before the existing `len()` check
- 5 test cases covering both issues

All existing tests pass. gofmt, go vet, and gocyclo (under 15) are clean. Happy to adjust the approach if you'd prefer a different fix. Thanks for maintaining bio-rd!
